### PR TITLE
feat: optimize dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM rust:latest
 WORKDIR /usr/src/app
+RUN echo "fn main() {}" > dummy.rs
+COPY mpc-recovery/Cargo.toml Cargo.toml
+RUN sed -i 's#src/main.rs#dummy.rs#' Cargo.toml
+RUN cargo build --release
 COPY . .
 RUN cargo install --path mpc-recovery/
 RUN mv /usr/local/cargo/bin/mpc-recovery /usr/local/bin/mpc-recovery

--- a/mpc-recovery/Cargo.toml
+++ b/mpc-recovery/Cargo.toml
@@ -3,6 +3,10 @@ name = "mpc-recovery"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+name = "mpc-recovery"
+path = "src/main.rs"
+
 # We have encountered issue with linking GMP on ARM macos machines. This is a temporary fix that
 # replaces GMP implementation with num-bigint.
 # [target.'cfg(macos)'.dependencies]


### PR DESCRIPTION
This cool tricks makes Docker cache compiled libraries if you don't change `mpc-recovery/Cargo.toml`.

Reduces build times (except for the very first one of course) on my machine to under a minute.