### PR TITLE
docker: quicker CI runs by caching intermediate layers

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           context: .
           tags: near/mpc-recovery:latest
+          load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Test


### PR DESCRIPTION
Leverage Docker caches to speed up CI builds

https://github.com/moby/buildkit#github-actions-cache-experimental

> caches are scoped by branch, with the default and target branches being available to every branch.