### PR TITLE
Google PK for signature verification

### DIFF
--- a/mpc-recovery/src/oauth.rs
+++ b/mpc-recovery/src/oauth.rs
@@ -85,7 +85,7 @@ impl OAuthTokenVerifier for PagodaFirebaseTokenVerifier {
 
         let claims = Self::validate_jwt(
             token,
-            &public_key.as_bytes(),
+            public_key.as_bytes(),
             &pagoda_firebase_issuer_id,
             &pagoda_firebase_audience_id,
         )


### PR DESCRIPTION
Get's the PK from Google server, no proper error handling at the moment.