### PR TITLE
chore: bump setup-protoc version

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -21,7 +21,7 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v1.1.2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Build Docker image

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v1.1.2
       - name: Compile
         run: cargo check
       - name: Test format


### PR DESCRIPTION
Fixes the rate-limiting issue reported in https://github.com/near/mpc-recovery/pull/40#issuecomment-1505993694.

See https://github.com/actions/runner-images/issues/602 for more context.