### PR TITLE
fix: various macos issues

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,15 @@
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-L", "/opt/homebrew/lib",
+  "-L", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib",
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-L", "/opt/homebrew/lib",
+  "-L", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib",
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -13,8 +13,6 @@ jobs:
     name: Test
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: 'true'
       - uses: actions/checkout@v3
         with:
           repository: 'near/pagoda-relayer-rs-fastauth'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,6 @@ jobs:
     name: Test
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: 'true'
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -36,8 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: 'true'
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,11 @@ RUN apt-get update \
 RUN echo "fn main() {}" > dummy.rs
 COPY mpc-recovery/Cargo.toml Cargo.toml
 RUN sed -i 's#src/main.rs#dummy.rs#' Cargo.toml
-RUN sed -i 's#mpc-recovery-gcp = { path = "../mpc-recovery-gcp" }##' Cargo.toml
 RUN cargo build --release
 COPY . .
 RUN cargo build --release --package mpc-recovery
 
-FROM debian:buster-slim as runtime
+FROM debian:bullseye-slim as runtime
 RUN apt-get update && apt-get install --assume-yes libssl-dev ca-certificates
 RUN update-ca-certificates
 COPY --from=builder /usr/src/app/target/release/mpc-recovery /usr/local/bin/mpc-recovery

--- a/README.md
+++ b/README.md
@@ -56,14 +56,9 @@ Internally, we are identifying users by their issuer id (iss) and their unique I
 
 ### Contribute
 
-In order to build the project, you will need to have `protoc` installed and execute the following:
+In order to build the project, you will need to have `protoc` and `gmp` installed. Refer to your system's package manager on how to do this.
 
-```BASH
-# init submodules
-git submodule update --init --recursive
-```
-
-alternatively if you have [nix](https://nixos.org/) and [direnv](https://direnv.net/) installed, you can set up a development environment by running:
+If you have [nix](https://nixos.org/) and [direnv](https://direnv.net/) installed, you can set up a development environment by running:
 
 ```BASH
 direnv allow

--- a/integration-tests/tests/lib.rs
+++ b/integration-tests/tests/lib.rs
@@ -110,7 +110,7 @@ where
     .await?;
 
     // Wait until all nodes initialize
-    tokio::time::sleep(Duration::from_millis(2000)).await;
+    tokio::time::sleep(Duration::from_millis(10000)).await;
 
     let result = f(TestContext {
         leader_node: &leader_node,

--- a/mpc-recovery/Cargo.toml
+++ b/mpc-recovery/Cargo.toml
@@ -7,15 +7,6 @@ edition = "2021"
 name = "mpc-recovery"
 path = "src/main.rs"
 
-# We have encountered issue with linking GMP on ARM macos machines. This is a temporary fix that
-# replaces GMP implementation with num-bigint.
-# [target.'cfg(macos)'.dependencies]
-# curv = { package = "curv-kzen", version = "0.9", default-features = false, features = ["num-bigint"] }
-# multi-party-eddsa = { git = "https://github.com/ZenGo-X/multi-party-eddsa.git", default-features = false }
-
-# [target.'cfg(unix)'.dependencies]
-# multi-party-eddsa = { git = "https://github.com/ZenGo-X/multi-party-eddsa.git" }
-
 [dependencies]
 actix-rt = "2.8"
 anyhow = "1"

--- a/mpc-recovery/src/gcp/mod.rs
+++ b/mpc-recovery/src/gcp/mod.rs
@@ -103,6 +103,7 @@ impl GcpService {
             read_options: None,
             database_id: Some("".to_string()),
         };
+        tracing::debug!(?request);
         let (_, response) = self
             .datastore
             .projects()
@@ -138,6 +139,7 @@ impl GcpService {
             single_use_transaction: None,
             transaction: None,
         };
+        tracing::debug!(?request);
         let (_, response) = self
             .datastore
             .projects()


### PR DESCRIPTION
Fixes #117 

Bumps sleeping time from 2s to 10s to ensure datastore emulator has initialized (ideally we should properly inspect logs for the starting condition, but who has time for that?).

Also adds `.cargo/config` that automatically links homebrew files (needed for GMP). @DavidM-D can you make sure this is not breaking your nix flow?

plus some minor cleanups after #103 got merged and we no longer have submodules