### PR TITLE
fix: failed broadcast should not fail

### DIFF
--- a/mpc-recovery/src/leader_node/mod.rs
+++ b/mpc-recovery/src/leader_node/mod.rs
@@ -94,7 +94,7 @@ pub async fn run<T: OAuthTokenVerifier + 'static>(config: Config) {
         Ok(messages) => messages,
         Err(err) => {
             tracing::error!("Unable to broadcast public keys: {err}");
-            return;
+            Vec::new()
         }
     };
     tracing::debug!(?messages, "broadcasted public key statuses");


### PR DESCRIPTION
If node already knows the public key set, that should not be an error