### PR TITLE
leader and signing node credentials API

### DIFF
--- a/mpc-recovery/src/msg.rs
+++ b/mpc-recovery/src/msg.rs
@@ -19,6 +19,21 @@ pub enum ClaimOidcResponse {
     Ok {
         #[serde(with = "hex_sig_share")]
         mpc_signature: Signature,
+    },
+    Err {
+        msg: String,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CredentialsRequest {
+    // In case OIDC token is not provided, only MPC signature is returned
+    pub oidc_token: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum CredentialsResponse {
+    Ok {
         mpc_pk: String,
         recovery_public_key: Option<String>,
         near_account_id: Option<String>,


### PR DESCRIPTION
Moving this changes to a separate PR to make them more visible.
It appeared, that it is not possible to get user PK during token claiming, because we are not passing the token itself.

We can pass internal user id from FE, but it will mean exposure of the internal logic. And this logic (internal user identifier) can be changed soon which will lead to breaking changes on FE side.

I have added a separate credentials endpoint that can fetch both user and mpc PK in one call. Since we can not afford to make too many calls to the signing nodes (very slow process) I have done the same for signing nodes by replasing `public_key` and `public_key_node` with `credentials` endpoint.

If there is no strong objections or ideas with better design, let's merge this PR and continue the work (PR is targeting another feature branch).