### PR TITLE
feat: add prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ dependencies = [
  "log",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.37.20",
  "slab",
  "socket2",
  "waker-fn",
@@ -289,7 +289,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 0.37.20",
  "signal-hook",
  "windows-sys 0.48.0",
 ]
@@ -2188,7 +2188,7 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
+ "rustix 0.37.20",
  "windows-sys 0.48.0",
 ]
 
@@ -2298,6 +2298,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2420,12 +2426,14 @@ dependencies = [
  "hyper",
  "hyper-rustls 0.23.2",
  "jsonwebtoken",
+ "lazy_static",
  "multi-party-eddsa",
  "near-crypto",
  "near-jsonrpc-client",
  "near-jsonrpc-primitives",
  "near-primitives",
  "oauth2",
+ "prometheus",
  "rand 0.7.3",
  "rand 0.8.5",
  "reqwest",
@@ -3133,7 +3141,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -3342,6 +3350,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1de8dacb0873f77e6aefc6d71e044761fcc68060290f5b1089fcdf84626bb69"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "hex 0.4.3",
+ "lazy_static",
+ "rustix 0.36.14",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3350,8 +3371,10 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
+ "libc",
  "memchr",
  "parking_lot",
+ "procfs",
  "protobuf",
  "thiserror",
 ]
@@ -3845,6 +3868,20 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.36.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e4d67015953998ad0eb82887a0eb0129e18a7e2f3b7b0f6c422fddcd503d62"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
 version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
@@ -3853,7 +3890,7 @@ dependencies = [
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
  "windows-sys 0.48.0",
 ]
 
@@ -4434,7 +4471,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix",
+ "rustix 0.37.20",
  "windows-sys 0.48.0",
 ]
 
@@ -5256,7 +5293,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -5276,11 +5313,35 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/mpc-recovery/Cargo.toml
+++ b/mpc-recovery/Cargo.toml
@@ -23,7 +23,9 @@ hex = "0.4"
 hyper = { version = "0.14", features = ["full"] }
 hyper-rustls = { version = "=0.23", features = ["http2"] }
 jsonwebtoken = "8.3.0"
+lazy_static = "1.4.0"
 oauth2 = "4.3.0"
+prometheus = { version = "0.13.3", features = ["process"] }
 rand = "0.7"
 rand8 = { package = "rand", version = "0.8" }
 reqwest = "0.11.16"

--- a/mpc-recovery/src/lib.rs
+++ b/mpc-recovery/src/lib.rs
@@ -10,6 +10,7 @@ use multi_party_eddsa::protocols::ExpandedKeyPair;
 pub mod gcp;
 pub mod key_recovery;
 pub mod leader_node;
+pub mod metrics;
 pub mod msg;
 pub mod nar;
 pub mod oauth;

--- a/mpc-recovery/src/metrics.rs
+++ b/mpc-recovery/src/metrics.rs
@@ -1,0 +1,43 @@
+use prometheus::{register_int_counter_vec, HistogramVec, IntCounterVec};
+
+use lazy_static::lazy_static;
+use prometheus::{opts, register_histogram_vec};
+
+const EXPONENTIAL_SECONDS: &[f64] = &[
+    0.001, 0.002, 0.004, 0.008, 0.016, 0.032, 0.064, 0.128, 0.256, 0.512, 1.024, 2.048, 4.096,
+    8.192, 16.384, 32.768,
+];
+
+lazy_static! {
+    pub static ref HTTP_REQUEST_COUNT: IntCounterVec = register_int_counter_vec!(
+        opts!(
+            "mpc_http_total_count",
+            "Total count of HTTP RPC requests received, by method and path"
+        ),
+        &["method", "path"]
+    )
+    .expect("can't create a metric");
+    pub static ref HTTP_CLIENT_ERROR_COUNT: IntCounterVec = register_int_counter_vec!(
+        opts!(
+            "mpc_http_client_error_count",
+            "Total count of client errors (4xx) by method and path"
+        ),
+        &["method", "path"]
+    )
+    .expect("can't create a metric");
+    pub static ref HTTP_SERVER_ERROR_COUNT: IntCounterVec = register_int_counter_vec!(
+        opts!(
+            "mpc_http_server_error_count",
+            "Total count of server errors (5xx) by method and path"
+        ),
+        &["method", "path"]
+    )
+    .expect("can't create a metric");
+    pub static ref HTTP_PROCESSING_TIME: HistogramVec = register_histogram_vec!(
+        "mpc_http_processing_time",
+        "Time taken to process HTTP requests in seconds",
+        &["method", "path"],
+        EXPONENTIAL_SECONDS.to_vec(),
+    )
+    .expect("can't create a metric");
+}


### PR DESCRIPTION
Relates to #183 

This PR introduces basic Prometheus metrics for our HTTP endpoints (total request count, 4xx response count, 5xx response count, processing time). It exposes them under an unprotected `/metrics` endpoint. It is debatable whether Prometheus endpoints should be protected (they were originally designed to be available to the general public, but there are many arguments against this in the modern world). I think we should add an auth/encryption mechanism here to be on the safe side. If someone here is an expert on the topic please let yourself known :)