### PR TITLE
chore: enable anyhow backtrace by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,9 @@ name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arbitrary"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { version = "1.0", features = ["backtrace"] }
 bollard = "0.11"
 clap = { version = "4.2", features = ["derive", "env"] }
 ed25519-dalek = {version = "1.0.1", features = ["serde"]}


### PR DESCRIPTION
Just run integration tests with `RUST_BACKTRACE=1` and you should get a backtrace by default now