### PR TITLE
User Credentials FRP turned on

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Returns the MPC public key that is used to sign the OIDC claiming response. Shou
 Returns the recovery public key associated with the provided OIDC token.
 The frp_signature you send must be an Ed22519 signature of the hash:
 
-    sha256.hash(Borsh.serialize<u32>(SALT + 3) ++ Borsh.serialize<[u8]>(oidc_token_hash, frp_public_key))
+    sha256.hash(Borsh.serialize<u32>(SALT + 2) ++ Borsh.serialize<[u8]>(oidc_token_hash, frp_public_key))
 
 ### Create New Account
 
@@ -107,17 +107,11 @@ Newly created NEAR account will have two full access keys. One that was provided
 
 In the future, MPC Service will disallow creating account with ID Tokes that were not claimed first. It is expected, that PK that client wants to use for the account creation is the same as the one that was used to claim the ID Token.
 
-The mpc_signature field is a signature of:
+The frp_signature you send must be an Ed22519 signature of the hash:
 
-    sha256.hash(Borsh.serialize<u32>(SALT + 2) ++ Borsh.serialize({
-        near_account_id,
-        create_account_options,
-        oidc_token,
-        frp_public_key,
-    }))
+    sha256.hash(Borsh.serialize<u32>(SALT + 3) ++ Borsh.serialize<[u8]>(oidc_token_hash, frp_public_key))
 
-signed by the key you used to claim the oidc token. This does not have to be the same as the key in the public key field.
-
+signed by the key you used to claim the oidc token. This does not have to be the same as the key in the public key field. This digest is the same as the one used in the user_credentials endpoint, because new_account request needs to get the recovery public key of the user that is creating the account.
 
 ### Sign
 
@@ -140,7 +134,7 @@ This endpoint can be used to sign a delegate action that can then be sent to the
 
 The frp_signature you send must be an Ed22519 signature of the hash:
 
-    sha256.hash(Borsh.serialize<u32>(SALT + 4) ++ Borsh.serialize<[u8]>(
+    sha256.hash(Borsh.serialize<u32>(SALT + 3) ++ Borsh.serialize<[u8]>(
         delegate_action,
         oidc_token_hash,
         frp_public_key,

--- a/integration-tests/tests/lib.rs
+++ b/integration-tests/tests/lib.rs
@@ -4,7 +4,9 @@ use curv::elliptic::curves::{Ed25519, Point};
 use futures::future::BoxFuture;
 use hyper::StatusCode;
 use mpc_recovery::{
-    msg::{ClaimOidcResponse, MpcPkResponse, NewAccountResponse, SignResponse},
+    msg::{
+        ClaimOidcResponse, MpcPkResponse, NewAccountResponse, SignResponse, UserCredentialsResponse,
+    },
     GenerateResult,
 };
 use mpc_recovery_integration_tests::containers;
@@ -266,3 +268,4 @@ impl_mpc_check!(SignResponse);
 impl_mpc_check!(NewAccountResponse);
 impl_mpc_check!(MpcPkResponse);
 impl_mpc_check!(ClaimOidcResponse);
+impl_mpc_check!(UserCredentialsResponse);

--- a/mpc-recovery/src/leader_node/mod.rs
+++ b/mpc-recovery/src/leader_node/mod.rs
@@ -405,12 +405,13 @@ async fn process_new_account<T: OAuthTokenVerifier>(
             )
             .await?;
 
+        // FRP signature here is a signature of the user_credentials request
         let mpc_user_recovery_pk = get_user_recovery_pk(
             &state.reqwest_client,
             &state.sign_nodes,
             request.oidc_token.clone(),
-            request.frp_signature, // TODO: this signature is worng and works only because FRP protection is turned of for now
-            request.frp_public_key.clone(), // TODO: this public key is worng and works only because FRP protection is turned of for now
+            request.frp_signature,
+            request.frp_public_key.clone(),
         )
         .await?;
 

--- a/mpc-recovery/src/msg.rs
+++ b/mpc-recovery/src/msg.rs
@@ -74,10 +74,18 @@ pub struct UserCredentialsRequest {
     pub frp_public_key: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
 pub enum UserCredentialsResponse {
     Ok { recovery_pk: String },
     Err { msg: String },
+}
+
+impl UserCredentialsResponse {
+    pub fn err(msg: String) -> Self {
+        UserCredentialsResponse::Err { msg }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/mpc-recovery/src/primitives.rs
+++ b/mpc-recovery/src/primitives.rs
@@ -4,9 +4,8 @@ pub type InternalAccountId = String; // format: "iss:sub" from the ID token
 pub enum HashSalt {
     ClaimOidcRequest = 0,
     ClaimOidcResponse = 1,
-    NewAccountRequest = 2,
-    UserCredentialsRequest = 3,
-    SignRequest = 4,
+    UserCredentialsRequest = 2,
+    SignRequest = 3,
 }
 
 // Mentioned in the readme, here to avoid collisions with legitimate transactions

--- a/mpc-recovery/src/utils.rs
+++ b/mpc-recovery/src/utils.rs
@@ -5,12 +5,12 @@ use near_crypto::PublicKey;
 use near_primitives::delegate_action::DelegateAction;
 use sha2::{Digest, Sha256};
 
-use crate::{primitives::HashSalt, sign_node::CommitError, transaction::CreateAccountOptions};
+use crate::{primitives::HashSalt, sign_node::CommitError};
 
 pub fn claim_oidc_request_digest(
     oidc_token_hash: [u8; 32],
     frp_public_key: PublicKey,
-) -> Result<Vec<u8>, CommitError> {
+) -> anyhow::Result<Vec<u8>> {
     // As per the readme
     // To verify the signature of the message verify:
     // sha256.hash(Borsh.serialize<u32>(SALT + 0) ++ Borsh.serialize<[u8]>(oidc_token_hash))
@@ -55,23 +55,6 @@ pub fn user_credentials_request_digest(
     let mut hasher = Sha256::default();
     BorshSerialize::serialize(&HashSalt::UserCredentialsRequest.get_salt(), &mut hasher)
         .context("Serialization failed")?;
-    BorshSerialize::serialize(&oidc_token, &mut hasher).context("Serialization failed")?;
-    BorshSerialize::serialize(&frp_public_key, &mut hasher).context("Serialization failed")?;
-    Ok(hasher.finalize().to_vec())
-}
-
-pub fn new_account_request_digest(
-    account_id: String,
-    _create_account_options: CreateAccountOptions,
-    oidc_token: String,
-    frp_public_key: PublicKey,
-) -> Result<Vec<u8>, CommitError> {
-    let mut hasher = Sha256::default();
-    BorshSerialize::serialize(&HashSalt::NewAccountRequest.get_salt(), &mut hasher)
-        .context("Serialization failed")?;
-    BorshSerialize::serialize(&account_id, &mut hasher).context("Serialization failed")?;
-    // BorshSerialize::serialize(&create_account_options, &mut hasher) // TODO: add borsh serialization for CreateAccountOptions
-    //     .context("Serialization failed")?;
     BorshSerialize::serialize(&oidc_token, &mut hasher).context("Serialization failed")?;
     BorshSerialize::serialize(&frp_public_key, &mut hasher).context("Serialization failed")?;
     Ok(hasher.finalize().to_vec())


### PR DESCRIPTION
- user recovery FRP turned on
- FRP digest signature removed from new_account, since it does not make sence to send it. Instead, we are sending user_credentials digest, because it's needed to create and account
- test refactoring