### PR TITLE
chore: Cleanup public key in messages

### DIFF
--- a/integration-tests/src/containers.rs
+++ b/integration-tests/src/containers.rs
@@ -665,7 +665,7 @@ impl LeaderNodeApi {
             create_account_options,
             oidc_token: oidc_token.to_string(),
             user_credentials_frp_signature: frp_signature,
-            frp_public_key: user_pk.clone().to_string(),
+            frp_public_key: user_pk.clone(),
         };
 
         self.new_account(new_account_request).await
@@ -706,7 +706,7 @@ impl LeaderNodeApi {
             oidc_token: oidc_token.to_string(),
             frp_signature,
             user_credentials_frp_signature,
-            frp_public_key: frp_pk.to_string(),
+            frp_public_key: frp_pk.clone(),
         };
         // Send SignRequest to leader node
         let (status_code, sign_response): (_, SignResponse) = self.sign(sign_request).await?;
@@ -762,7 +762,7 @@ impl LeaderNodeApi {
             oidc_token: oidc_token.to_string(),
             frp_signature,
             user_credentials_frp_signature,
-            frp_public_key: frp_pk.to_string(),
+            frp_public_key: frp_pk.clone(),
         };
         // Send SignRequest to leader node
         let (status_code, sign_response): (_, SignResponse) = self.sign(sign_request).await?;
@@ -805,7 +805,7 @@ impl LeaderNodeApi {
             oidc_token: oidc_token.to_string(),
             frp_signature,
             user_credentials_frp_signature,
-            frp_public_key: frp_pk.to_string(),
+            frp_public_key: frp_pk.clone(),
         };
         // Send SignRequest to leader node
         let (status_code, sign_response): (_, SignResponse) = self.sign(sign_request).await?;
@@ -863,7 +863,7 @@ impl LeaderNodeApi {
         self.user_credentials(UserCredentialsRequest {
             oidc_token: oidc_token.to_string(),
             frp_signature,
-            frp_public_key: client_pk.to_string(),
+            frp_public_key: client_pk.clone(),
         })
         .await
     }

--- a/integration-tests/tests/mpc/mod.rs
+++ b/integration-tests/tests/mpc/mod.rs
@@ -1,4 +1,3 @@
-use std::str::FromStr;
 use std::time::Duration;
 
 use mpc_recovery::msg::{NewAccountResponse, UserCredentialsResponse};
@@ -76,7 +75,7 @@ pub async fn fetch_recovery_pk(
         .await?
         .assert_ok()?
     {
-        UserCredentialsResponse::Ok { recovery_pk } => PublicKey::from_str(&recovery_pk)?,
+        UserCredentialsResponse::Ok { recovery_pk } => recovery_pk,
         UserCredentialsResponse::Err { msg } => anyhow::bail!("error response: {}", msg),
     };
     Ok(recovery_pk)

--- a/integration-tests/tests/mpc/negative.rs
+++ b/integration-tests/tests/mpc/negative.rs
@@ -8,7 +8,6 @@ use mpc_recovery::{
     utils::{claim_oidc_request_digest, claim_oidc_response_digest, oidc_digest, sign_digest},
 };
 use multi_party_eddsa::protocols::ExpandedKeyPair;
-use near_crypto::PublicKey;
 use near_primitives::{
     account::AccessKey,
     delegate_action::DelegateAction,
@@ -97,7 +96,7 @@ async fn whitlisted_actions_test() -> anyhow::Result<()> {
                 .await?
                 .assert_ok()?
             {
-                UserCredentialsResponse::Ok { recovery_pk } => PublicKey::from_str(&recovery_pk)?,
+                UserCredentialsResponse::Ok { recovery_pk } => recovery_pk,
                 UserCredentialsResponse::Err { msg } => {
                     return Err(anyhow::anyhow!("error response: {}", msg))
                 }
@@ -423,7 +422,7 @@ async fn test_invalid_token() -> anyhow::Result<()> {
                 .await?
                 .assert_ok()?
             {
-                UserCredentialsResponse::Ok { recovery_pk } => PublicKey::from_str(&recovery_pk)?,
+                UserCredentialsResponse::Ok { recovery_pk } => recovery_pk,
                 UserCredentialsResponse::Err { msg } => anyhow::bail!("error response: {}", msg),
             };
 

--- a/mpc-recovery/src/key_recovery.rs
+++ b/mpc-recovery/src/key_recovery.rs
@@ -20,12 +20,12 @@ pub async fn get_user_recovery_pk(
     sign_nodes: &[String],
     oidc_token: &str,
     frp_signature: Signature,
-    frp_public_key: String,
+    frp_public_key: &PublicKey,
 ) -> anyhow::Result<PublicKey, NodeRecoveryError> {
     let request = PublicKeyNodeRequest {
         oidc_token: oidc_token.to_string(),
         frp_signature,
-        frp_public_key,
+        frp_public_key: frp_public_key.clone(),
     };
     let res = call_all_nodes(client, sign_nodes, "public_key", request).await?;
 

--- a/mpc-recovery/src/leader_node/mod.rs
+++ b/mpc-recovery/src/leader_node/mod.rs
@@ -345,12 +345,12 @@ async fn process_user_credentials<T: OAuthTokenVerifier>(
             &state.sign_nodes,
             &request.oidc_token,
             request.frp_signature,
-            request.frp_public_key.clone(),
+            &request.frp_public_key,
         )
         .await?;
 
         Ok(UserCredentialsResponse::Ok {
-            recovery_pk: mpc_user_recovery_pk.to_string(),
+            recovery_pk: mpc_user_recovery_pk,
         })
     })
     .await
@@ -409,7 +409,7 @@ async fn process_new_account<T: OAuthTokenVerifier>(
             &state.sign_nodes,
             &request.oidc_token,
             request.user_credentials_frp_signature,
-            request.frp_public_key.clone(),
+            &request.frp_public_key,
         )
         .await?;
 
@@ -588,7 +588,7 @@ async fn process_sign<T: OAuthTokenVerifier>(
             &state.sign_nodes,
             &request.oidc_token,
             request.user_credentials_frp_signature,
-            request.frp_public_key.clone(),
+            &request.frp_public_key,
         )
         .await?;
 
@@ -624,7 +624,7 @@ async fn process_sign<T: OAuthTokenVerifier>(
             &request.oidc_token,
             request.delegate_action.clone(),
             request.frp_signature,
-            request.frp_public_key.clone(),
+            &request.frp_public_key,
         )
         .await?;
 

--- a/mpc-recovery/src/msg.rs
+++ b/mpc-recovery/src/msg.rs
@@ -71,14 +71,14 @@ impl TryInto<Signature> for ClaimOidcResponse {
 pub struct UserCredentialsRequest {
     pub oidc_token: String,
     pub frp_signature: Signature,
-    pub frp_public_key: String,
+    pub frp_public_key: near_crypto::PublicKey,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type")]
 #[serde(rename_all = "snake_case")]
 pub enum UserCredentialsResponse {
-    Ok { recovery_pk: String },
+    Ok { recovery_pk: near_crypto::PublicKey },
     Err { msg: String },
 }
 
@@ -94,7 +94,7 @@ pub struct NewAccountRequest {
     pub create_account_options: CreateAccountOptions,
     pub oidc_token: String,
     pub user_credentials_frp_signature: Signature,
-    pub frp_public_key: String,
+    pub frp_public_key: near_crypto::PublicKey,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -123,7 +123,7 @@ pub struct SignRequest {
     pub oidc_token: String,
     pub frp_signature: Signature,
     pub user_credentials_frp_signature: Signature,
-    pub frp_public_key: String,
+    pub frp_public_key: near_crypto::PublicKey,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -152,7 +152,7 @@ pub struct SignShareNodeRequest {
     pub oidc_token: String,
     pub delegate_action: DelegateAction,
     pub frp_signature: Signature,
-    pub frp_public_key: String,
+    pub frp_public_key: near_crypto::PublicKey,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -167,7 +167,7 @@ pub struct ClaimOidcNodeRequest {
 pub struct PublicKeyNodeRequest {
     pub oidc_token: String,
     pub frp_signature: Signature,
-    pub frp_public_key: String,
+    pub frp_public_key: near_crypto::PublicKey,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/mpc-recovery/src/transaction.rs
+++ b/mpc-recovery/src/transaction.rs
@@ -101,13 +101,13 @@ pub async fn get_mpc_signature(
     oidc_token: &str,
     delegate_action: DelegateAction,
     frp_signature: Signature,
-    frp_public_key: String,
+    frp_public_key: &near_crypto::PublicKey,
 ) -> Result<Signature, NodeSignError> {
     let sig_share_request = SignNodeRequest::SignShare(SignShareNodeRequest {
         oidc_token: oidc_token.to_string(),
         delegate_action,
         frp_signature,
-        frp_public_key,
+        frp_public_key: frp_public_key.clone(),
     });
 
     let signature = sign_payload_with_mpc(client, sign_nodes, sig_share_request).await?;


### PR DESCRIPTION
Another thing that was nice just to cleanup. Shouldn't be touching anything public either ways, and was better to just directly send the key type over the wire. Let me know if there was any reason why we were using `String` over `PublicKey` in `msg.rs` structs though