### PR TITLE
chore: Added malformed for testing requests that are invalid

### DIFF
--- a/integration-tests/tests/lib.rs
+++ b/integration-tests/tests/lib.rs
@@ -138,6 +138,12 @@ mod key {
     use near_crypto::{PublicKey, SecretKey};
     use rand::{distributions::Alphanumeric, Rng};
 
+    pub fn random() -> (SecretKey, PublicKey) {
+        let sk = random_sk();
+        let pk = sk.public_key();
+        (sk, pk)
+    }
+
     pub fn random_sk() -> SecretKey {
         near_crypto::SecretKey::from_random(near_crypto::KeyType::ED25519)
     }


### PR DESCRIPTION
So, I figured to test malformed requests the best, we shouldn't be encoding them as types, since those are already supposed to be correctly parsed and in no way should be mixed with dynamic data types like Strings or byte arrays.

This simply just tests endpoints by sending raw request data and expect a status code along with an error message. This flushes out any sort of errors along the way such as deserialization errors that weren't being handled before and being responded with a status code