### PR TITLE
Remove CORs TODO

### DIFF
--- a/mpc-recovery/src/leader_node/mod.rs
+++ b/mpc-recovery/src/leader_node/mod.rs
@@ -113,7 +113,7 @@ pub async fn run<T: OAuthTokenVerifier + 'static>(config: Config) {
     };
     tracing::debug!(?messages, "broadcasted public key statuses");
 
-    //TODO: not secure, allow only for testnet, whitelist endpoint etc. for mainnet
+    // Cors layer is move to load balancer
     let cors_layer = tower_http::cors::CorsLayer::permissive();
 
     let app = Router::new()


### PR DESCRIPTION
After discussions with @MaximusHaximus  we agreed that handling CORs layer in Load Balancer is a better option, ideally with an allowlist of origins in Terraform config.