### PR TITLE
fix: Log missing Err(_) for GCP and metrics

### DIFF
--- a/mpc-recovery/src/leader_node/mod.rs
+++ b/mpc-recovery/src/leader_node/mod.rs
@@ -196,10 +196,13 @@ async fn metrics() -> (StatusCode, String) {
 
     match grab_metrics() {
         Ok(response) => (StatusCode::OK, response),
-        Err(_) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "failed to generate prometheus metrics".to_string(),
-        ),
+        Err(err) => {
+            tracing::error!("failed to generate prometheus metrics: {err}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to generate prometheus metrics".to_string(),
+            )
+        }
     }
 }
 

--- a/mpc-recovery/src/sign_node/mod.rs
+++ b/mpc-recovery/src/sign_node/mod.rs
@@ -515,10 +515,13 @@ async fn accept_pk_set(
             StatusCode::OK,
             Json(Ok("Successfully set node public keys".to_string())),
         ),
-        Err(_) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(Ok("failed to save the keys".to_string())),
-        ),
+        Err(err) => {
+            tracing::error!("Failed to save pk set due to GCP error: {err}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(Ok("failed to save node public keys".to_string())),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
Some errors were being consumed before and not getting logged. Log these just to see what's going on