### PR TITLE
feat: decouple secret management from terraform

### DIFF
--- a/.github/workflows/terraform-dev.yml
+++ b/.github/workflows/terraform-dev.yml
@@ -53,17 +53,19 @@ jobs:
         env:
           GOOGLE_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS_DEV }}
 
+      # Build Docker image.
+      - name: Docker Image
+        id: build
+        run: docker build .. -t near/mpc-recovery
+
       # Generates an execution plan for Terraform
       - name: Terraform Plan
         id: plan
         run: |
           terraform plan -input=false -no-color -lock-timeout=1h -var-file terraform-dev.tfvars \
-            -var "credentials=$GOOGLE_CREDENTIALS" \
-            -var "account_creator_id=mpc-recovery-dev-creator.testnet" \
-            -var "account_creator_sk=$ACCOUNT_CREATOR_SK"
+            -var "credentials=$GOOGLE_CREDENTIALS"
         env:
           GOOGLE_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS_DEV }}
-          ACCOUNT_CREATOR_SK: ${{ secrets.ACCOUNT_CREATOR_SK_DEV }}
 
       - uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
@@ -137,9 +139,6 @@ jobs:
         if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
         run: |
           terraform apply -auto-approve -input=false -lock-timeout=1h -var-file terraform-dev.tfvars \
-            -var "credentials=$GOOGLE_CREDENTIALS" \
-            -var "account_creator_id=mpc-recovery-dev-creator.testnet" \
-            -var "account_creator_sk=$ACCOUNT_CREATOR_SK"
+            -var "credentials=$GOOGLE_CREDENTIALS"
         env:
           GOOGLE_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS_DEV }}
-          ACCOUNT_CREATOR_SK: ${{ secrets.ACCOUNT_CREATOR_SK_DEV }}

--- a/.github/workflows/terraform-feature-env.yml
+++ b/.github/workflows/terraform-feature-env.yml
@@ -41,10 +41,18 @@ jobs:
           GOOGLE_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS_DEV }}
           PR_NUMBER: ${{ env.PR_NUMBER }}
 
+      # Build Docker image.
+      - name: Docker Image
+        id: build
+        run: docker build .. -t near/mpc-recovery
+
       # Applies Terraform configuration to the temporary environment
       - name: Terraform Apply
         id: apply
-        run: terraform apply -auto-approve -input=false -no-color -lock-timeout=1h -var-file terraform-dev.tfvars -var "credentials=$GOOGLE_CREDENTIALS" -var "env=dev-$PR_NUMBER"
+        run: |
+          terraform apply -auto-approve -input=false -no-color -lock-timeout=1h -var-file terraform-dev.tfvars \
+            -var "credentials=$GOOGLE_CREDENTIALS" \
+            -var "env=dev-$PR_NUMBER"
         env:
           GOOGLE_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS_DEV }}
           PR_NUMBER: ${{ env.PR_NUMBER }}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -56,6 +56,9 @@ provider "docker" {
   }
 }
 
+/*
+ * Create brand new service account with basic IAM
+ */
 resource "google_service_account" "service_account" {
   account_id   = "mpc-recovery-${var.env}"
   display_name = "MPC Recovery ${var.env} Account"
@@ -76,25 +79,66 @@ resource "google_project_iam_member" "service-account-datastore-user" {
   member  = "serviceAccount:${google_service_account.service_account.email}"
 }
 
+/*
+ * Ensure service account has access to Secret Manager variables
+ */
+resource "google_secret_manager_secret_iam_member" "cipher_key_secret_access" {
+  count = length(var.signer_configs)
+
+  secret_id = var.signer_configs[count.index].cipher_key_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "secret_share_secret_access" {
+  count = length(var.signer_configs)
+
+  secret_id = var.signer_configs[count.index].sk_share_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "oidc_providers_secret_access" {
+  secret_id = var.oidc_providers_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "account_creator_secret_access" {
+  secret_id = var.account_creator_sk_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "fast_auth_partners_secret_access" {
+  secret_id = var.fast_auth_partners_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+/*
+ * Create Artifact Registry repo, tag existing Docker image and push to the repo
+ */
 resource "google_artifact_registry_repository" "mpc_recovery" {
   repository_id = "mpc-recovery-${var.env}"
   format        = "DOCKER"
 }
 
 resource "docker_registry_image" "mpc_recovery" {
-  name          = docker_image.mpc_recovery.name
+  name          = docker_tag.mpc_recovery.target_image
   keep_remotely = true
 }
 
-resource "docker_image" "mpc_recovery" {
-  name = "${var.region}-docker.pkg.dev/${var.project}/${google_artifact_registry_repository.mpc_recovery.name}/mpc-recovery-${var.env}:${data.external.git_checkout.result.sha}"
-  build {
-    context = "${path.cwd}/.."
-  }
+resource "docker_tag" "mpc_recovery" {
+  source_image = var.docker_image
+  target_image = "${var.region}-docker.pkg.dev/${var.project}/${google_artifact_registry_repository.mpc_recovery.name}/mpc-recovery-${var.env}:${data.external.git_checkout.result.sha}"
 }
 
+/*
+ * Create multiple signer nodes
+ */
 module "signer" {
-  count  = length(var.cipher_keys)
+  count  = length(var.signer_configs)
   source = "./modules/signer"
 
   env                   = var.env
@@ -102,17 +146,25 @@ module "signer" {
   region                = var.region
   zone                  = var.zone
   service_account_email = google_service_account.service_account.email
-  docker_image          = docker_image.mpc_recovery.name
+  docker_image          = docker_tag.mpc_recovery.target_image
 
-  node_id        = count.index
-  oidc_providers = var.oidc_providers
+  node_id = count.index
 
-  cipher_key = var.cipher_keys[count.index]
-  sk_share   = var.sk_shares[count.index]
+  oidc_providers_secret_id = var.oidc_providers_secret_id
+  cipher_key_secret_id     = var.signer_configs[count.index].cipher_key_secret_id
+  sk_share_secret_id       = var.signer_configs[count.index].sk_share_secret_id
 
-  depends_on = [docker_registry_image.mpc_recovery]
+  depends_on = [
+    docker_registry_image.mpc_recovery,
+    google_secret_manager_secret_iam_member.cipher_key_secret_access,
+    google_secret_manager_secret_iam_member.secret_share_secret_access,
+    google_secret_manager_secret_iam_member.oidc_providers_secret_access
+  ]
 }
 
+/*
+ * Create leader node
+ */
 module "leader" {
   source = "./modules/leader"
 
@@ -121,15 +173,20 @@ module "leader" {
   region                = var.region
   zone                  = var.zone
   service_account_email = google_service_account.service_account.email
-  docker_image          = docker_image.mpc_recovery.name
+  docker_image          = docker_tag.mpc_recovery.target_image
 
   signer_node_urls   = concat(module.signer.*.node.uri, var.external_signer_node_urls)
   near_rpc           = local.workspace.near_rpc
   near_root_account  = local.workspace.near_root_account
   account_creator_id = var.account_creator_id
-  fast_auth_partners = var.fast_auth_partners
 
-  account_creator_sk = var.account_creator_sk
+  account_creator_sk_secret_id = var.account_creator_sk_secret_id
+  fast_auth_partners_secret_id = var.fast_auth_partners_secret_id
 
-  depends_on = [docker_registry_image.mpc_recovery, module.signer]
+  depends_on = [
+    docker_registry_image.mpc_recovery,
+    google_secret_manager_secret_iam_member.account_creator_secret_access,
+    google_secret_manager_secret_iam_member.fast_auth_partners_secret_access,
+    module.signer
+  ]
 }

--- a/infra/modules/leader/variables.tf
+++ b/infra/modules/leader/variables.tf
@@ -1,19 +1,25 @@
 variable "env" {
+  type = string
 }
 
 variable "project" {
+  type = string
 }
 
 variable "region" {
+  type = string
 }
 
 variable "zone" {
+  type = string
 }
 
 variable "service_account_email" {
+  type = string
 }
 
 variable "docker_image" {
+  type = string
 }
 
 # Application variables
@@ -22,28 +28,22 @@ variable "signer_node_urls" {
 }
 
 variable "near_rpc" {
+  type = string
 }
 
 variable "near_root_account" {
+  type = string
 }
 
 variable "account_creator_id" {
-}
-
-variable "fast_auth_partners" {
-  type = list(object({
-    oidc_provider = object({
-      issuer   = string
-      audience = string
-    })
-    relayer = object({
-      url     = string
-      api_key = string
-    })
-  }))
-  default = []
+  type = string
 }
 
 # Secrets
-variable "account_creator_sk" {
+variable "account_creator_sk_secret_id" {
+  type = string
+}
+
+variable "fast_auth_partners_secret_id" {
+  type = string
 }

--- a/infra/modules/signer/variables.tf
+++ b/infra/modules/signer/variables.tf
@@ -20,17 +20,15 @@ variable "docker_image" {
 variable "node_id" {
 }
 
-variable "oidc_providers" {
-  type = list(object({
-    issuer   = string
-    audience = string
-  }))
-  default = []
-}
-
 # Secrets
-variable "cipher_key" {
+variable "cipher_key_secret_id" {
+  type = string
 }
 
-variable "sk_share" {
+variable "sk_share_secret_id" {
+  type = string
+}
+
+variable "oidc_providers_secret_id" {
+  type = string
 }

--- a/infra/partner/main.tf
+++ b/infra/partner/main.tf
@@ -33,6 +33,9 @@ provider "docker" {
   }
 }
 
+/*
+ * Create brand new service account with basic IAM
+ */
 resource "google_service_account" "service_account" {
   account_id   = "mpc-recovery-${var.env}"
   display_name = "MPC Recovery ${var.env} Account"
@@ -56,8 +59,32 @@ resource "google_project_iam_binding" "service-account-datastore-user" {
   ]
 }
 
+/*
+ * Ensure service account has access to Secret Manager variables
+ */
+resource "google_secret_manager_secret_iam_member" "cipher_key_secret_access" {
+  secret_id = var.cipher_key_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "secret_share_secret_access" {
+  secret_id = var.sk_share_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "oidc_providers_secret_access" {
+  secret_id = var.oidc_providers_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+/*
+ * Create Artifact Registry repo, tag existing Docker image and push to the repo
+ */
 resource "google_artifact_registry_repository" "mpc_recovery" {
-  repository_id = "mpc-recovery-signer-${var.env}"
+  repository_id = "mpc-recovery-partner-${var.env}"
   format        = "DOCKER"
 }
 
@@ -71,13 +98,9 @@ resource "docker_tag" "mpc_recovery" {
   target_image = "${var.region}-docker.pkg.dev/${var.project}/${google_artifact_registry_repository.mpc_recovery.name}/mpc-recovery-${var.env}"
 }
 
-# resource "docker_image" "mpc_recovery" {
-#   name = "${var.region}-docker.pkg.dev/${var.project}/${google_artifact_registry_repository.mpc_recovery.name}/mpc-recovery-${var.env}"
-#   build {
-#     context = "${path.cwd}/.."
-#   }
-# }
-
+/*
+ * Create a partner signer node
+ */
 module "signer" {
   source = "../modules/signer"
 
@@ -90,8 +113,14 @@ module "signer" {
 
   node_id = var.node_id
 
-  cipher_key = var.cipher_key
-  sk_share   = var.sk_share
+  cipher_key_secret_id     = var.cipher_key_secret_id
+  sk_share_secret_id       = var.sk_share_secret_id
+  oidc_providers_secret_id = var.oidc_providers_secret_id
 
-  depends_on = [docker_registry_image.mpc_recovery]
+  depends_on = [
+    docker_registry_image.mpc_recovery,
+    google_secret_manager_secret_iam_member.cipher_key_secret_access,
+    google_secret_manager_secret_iam_member.secret_share_secret_access,
+    google_secret_manager_secret_iam_member.oidc_providers_secret_access
+  ]
 }

--- a/infra/partner/template.tfvars
+++ b/infra/partner/template.tfvars
@@ -1,0 +1,11 @@
+env     = "partner-dev"
+project = "pagoda-discovery-platform-dev"
+region  = "us-east1"
+zone    = "us-east1-c"
+
+docker_image = "near/mpc-recovery"
+node_id      = "0"
+
+oidc_providers_secret_id = "mpc-recovery-allowed-oidc-providers-0-dev"
+cipher_key_secret_id     = "mpc-recovery-encryption-cipher-0-dev"
+sk_share_secret_id       = "mpc-recovery-secret-share-0-dev"

--- a/infra/partner/variables.tf
+++ b/infra/partner/variables.tf
@@ -21,10 +21,14 @@ variable "node_id" {
 }
 
 # Secrets
-variable "cipher_key" {
+variable "cipher_key_secret_id" {
   type = string
 }
 
-variable "sk_share" {
+variable "sk_share_secret_id" {
+  type = string
+}
+
+variable "oidc_providers_secret_id" {
   type = string
 }

--- a/infra/terraform-dev.tfvars
+++ b/infra/terraform-dev.tfvars
@@ -1,33 +1,22 @@
-env     = "dev"
-project = "pagoda-discovery-platform-dev"
+env          = "dev"
+project      = "pagoda-discovery-platform-dev"
+docker_image = "near/mpc-recovery"
 
-account_creator_id = "tmp_acount_creator.serhii.testnet"
-account_creator_sk = "ed25519:5pFJN3czPAHFWHZYjD4oTtnJE7PshLMeTkSU7CmWkvLaQWchCLgXGF1wwcJmh2AQChGH85EwcL5VW7tUavcAZDSG"
-cipher_keys        = ["ea28abd17cb76924f62c99f6fd240985c16b9dc85187760c1487e64689d447f5", "cc7a448b28b2a58bada59770b6418ae75ade177abad216385e012805b9cfc8f9", "78be23c9400f4414c043aa966b51e44b3fa3ab790a1779d370d40589a7b02dd2"]
-sk_shares = [
-  "{\"public_key\":{\"curve\":\"ed25519\",\"point\":[44,250,33,208,230,210,1,232,218,250,54,239,72,81,92,99,10,169,178,160,155,203,106,27,68,188,121,148,143,199,6,241]},\"expanded_private_key\":{\"prefix\":{\"curve\":\"ed25519\",\"scalar\":[102,223,208,90,184,101,17,59,89,36,9,226,244,136,59,225,17,226,66,187,72,197,17,71,28,28,128,125,122,248,32,105]},\"private_key\":{\"curve\":\"ed25519\",\"scalar\":[240,196,61,168,214,169,50,27,103,54,246,131,195,119,194,74,24,183,7,164,92,165,213,35,130,63,118,52,70,141,108,97]}}}",
-  "{\"public_key\":{\"curve\":\"ed25519\",\"point\":[46,181,130,13,164,112,16,130,63,196,212,83,38,63,120,124,0,35,238,100,212,32,46,7,233,221,2,16,20,189,198,167]},\"expanded_private_key\":{\"prefix\":{\"curve\":\"ed25519\",\"scalar\":[35,145,79,79,99,72,33,94,114,179,89,56,252,168,145,28,195,10,230,89,247,39,194,127,202,75,119,182,59,120,144,83]},\"private_key\":{\"curve\":\"ed25519\",\"scalar\":[88,71,177,97,38,226,233,158,49,168,14,146,117,128,240,16,97,35,56,137,0,69,150,237,4,210,81,35,0,44,233,98]}}}",
-  "{\"public_key\":{\"curve\":\"ed25519\",\"point\":[226,221,12,58,210,76,171,11,139,88,242,44,18,207,126,120,5,90,208,108,4,93,19,188,24,172,130,61,51,94,10,34]},\"expanded_private_key\":{\"prefix\":{\"curve\":\"ed25519\",\"scalar\":[72,32,251,204,100,91,164,82,140,231,84,166,176,30,167,99,107,71,71,195,83,40,241,205,6,89,122,227,140,146,82,4]},\"private_key\":{\"curve\":\"ed25519\",\"scalar\":[8,248,184,114,40,88,141,189,156,115,215,171,36,210,85,189,12,217,176,9,208,28,141,207,18,18,57,230,231,14,118,116]}}}"
-]
-
-// For leader node
-fast_auth_partners = [
+account_creator_id           = "mpc-recovery-dev-creator.testnet"
+account_creator_sk_secret_id = "mpc-account-creator-sk-dev"
+oidc_providers_secret_id     = "mpc-allowed-oidc-providers-dev"
+fast_auth_partners_secret_id = "mpc-fast-auth-partners-dev"
+signer_configs = [
   {
-    oidc_provider = {
-      issuer   = "https://securetoken.google.com/pagoda-oboarding-dev",
-      audience = "pagoda-oboarding-dev"
-    },
-    relayer = {
-      url     = "http://34.70.226.83:3030",
-      api_key = null,
-    },
-  }
-]
-
-// For signing nodes
-oidc_providers = [
+    cipher_key_secret_id = "mpc-cipher-0-dev"
+    sk_share_secret_id   = "mpc-sk-share-0-dev"
+  },
   {
-    issuer   = "https://securetoken.google.com/pagoda-oboarding-dev",
-    audience = "pagoda-oboarding-dev"
+    cipher_key_secret_id = "mpc-cipher-1-dev"
+    sk_share_secret_id   = "mpc-sk-share-1-dev"
+  },
+  {
+    cipher_key_secret_id = "mpc-cipher-2-dev"
+    sk_share_secret_id   = "mpc-sk-share-2-dev"
   }
 ]

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -20,31 +20,13 @@ variable "zone" {
   default = "us-east1-c"
 }
 
+variable "docker_image" {
+  type = string
+}
+
 # Application variables
 variable "account_creator_id" {
   default = "tmp_acount_creator.serhii.testnet"
-}
-
-variable "fast_auth_partners" {
-  type = list(object({
-    oidc_provider = object({
-      issuer   = string
-      audience = string
-    })
-    relayer = object({
-      url     = string
-      api_key = string
-    })
-  }))
-  default = []
-}
-
-variable "oidc_providers" {
-  type = list(object({
-    issuer   = string
-    audience = string
-  }))
-  default = []
 }
 
 variable "external_signer_node_urls" {
@@ -53,13 +35,21 @@ variable "external_signer_node_urls" {
 }
 
 # Secrets
-variable "account_creator_sk" {
+variable "account_creator_sk_secret_id" {
+  type = string
 }
 
-variable "cipher_keys" {
-  type = list(string)
+variable "oidc_providers_secret_id" {
+  type = string
 }
 
-variable "sk_shares" {
-  type = list(string)
+variable "fast_auth_partners_secret_id" {
+  type = string
+}
+
+variable "signer_configs" {
+  type = list(object({
+    cipher_key_secret_id = string
+    sk_share_secret_id   = string
+  }))
 }


### PR DESCRIPTION
**WARNING: This PR is targeting `main`**

Apologies for the last minute changes, but the more I use terraform the less and less I like that we manage secrets through TF variables, it's even worse that we are planning to make our partners do the same (which mean they can't persist their `tfvars` file or ever share it with us for debugging). This PR makes so that all secret values are replaced with their secret ID counterparts (e.g. `account_creator_sk` -> `account_creator_sk_secret_id`), which presumes that the secret already exists and is managed outside of terraform.

This, against my initial concerns, does not create any complications for deploying feature envs as we can just safely share the secrets with `dev` enviornment and not store anything in git or even GHA.