### PR TITLE
feat: use local Lake Indexer in integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "event-listener 3.0.0",
  "futures-lite",
- "rustix 0.38.20",
+ "rustix 0.38.21",
  "windows-sys 0.48.0",
 ]
 
@@ -365,7 +365,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "futures-core",
  "futures-io",
- "rustix 0.38.20",
+ "rustix 0.38.21",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.48.0",
@@ -3262,7 +3262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.3",
- "rustix 0.38.20",
+ "rustix 0.38.21",
  "windows-sys 0.48.0",
 ]
 
@@ -5859,9 +5859,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.20"
+version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -6742,14 +6742,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand 2.0.1",
- "redox_syscall 0.3.5",
- "rustix 0.38.20",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.21",
  "windows-sys 0.48.0",
 ]
 
@@ -7644,7 +7644,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.20",
+ "rustix 0.38.21",
 ]
 
 [[package]]

--- a/integration-tests/src/env/containers.rs
+++ b/integration-tests/src/env/containers.rs
@@ -599,11 +599,14 @@ impl<'a> LakeIndexer<'a> {
             "running NEAR Lake Indexer container..."
         );
 
-        let image = GenericImage::new("near/near-lake-indexer", "latest")
-            .with_env_var("AWS_ACCESS_KEY_ID", "FAKE_LOCALSTACK_KEY_ID")
-            .with_env_var("AWS_SECRET_ACCESS_KEY", "FAKE_LOCALSTACK_ACCESS_KEY")
-            .with_wait_for(WaitFor::message_on_stderr("Starting Streamer"))
-            .with_exposed_port(Self::CONTAINER_RPC_PORT);
+        let image = GenericImage::new(
+            "ghcr.io/near/near-lake-indexer",
+            "e6519c922435f3d18b5f2ddac5d1ec171ef4dd6b",
+        )
+        .with_env_var("AWS_ACCESS_KEY_ID", "FAKE_LOCALSTACK_KEY_ID")
+        .with_env_var("AWS_SECRET_ACCESS_KEY", "FAKE_LOCALSTACK_ACCESS_KEY")
+        .with_wait_for(WaitFor::message_on_stderr("Starting Streamer"))
+        .with_exposed_port(Self::CONTAINER_RPC_PORT);
         let image: RunnableImage<GenericImage> = (
             image,
             vec![

--- a/integration-tests/src/env/containers.rs
+++ b/integration-tests/src/env/containers.rs
@@ -46,6 +46,7 @@ use crate::env::{Context, LeaderNodeApi, SignerNodeApi};
 use crate::util::{
     self, create_key_file, create_key_file_with_filepath, create_relayer_cofig_file,
 };
+use bollard::exec::CreateExecOptions;
 
 static NETWORK_MUTEX: Lazy<Mutex<i32>> = Lazy::new(|| Mutex::new(0));
 
@@ -493,6 +494,152 @@ impl<'a> Datastore<'a> {
             container,
             local_address,
             address: full_address,
+        })
+    }
+}
+
+pub struct LocalStack<'a> {
+    pub container: Container<'a, GenericImage>,
+    pub address: String,
+    pub s3_address: String,
+    pub s3_host_address: String,
+    pub s3_bucket: String,
+    pub s3_region: String,
+}
+
+impl<'a> LocalStack<'a> {
+    const S3_CONTAINER_PORT: u16 = 4566;
+
+    pub async fn run(
+        docker_client: &'a DockerClient,
+        network: &str,
+        s3_bucket: String,
+        s3_region: String,
+    ) -> anyhow::Result<LocalStack<'a>> {
+        tracing::info!("running LocalStack container...");
+        let image = GenericImage::new("localstack/localstack", "latest")
+            .with_exposed_port(Self::S3_CONTAINER_PORT)
+            .with_wait_for(WaitFor::message_on_stdout("Running on"));
+        let image: RunnableImage<GenericImage> = image.into();
+        let image = image.with_network(network);
+        let container = docker_client.cli.run(image);
+        let address = docker_client
+            .get_network_ip_address(&container, network)
+            .await?;
+
+        // Create the bucket
+        let create_result = docker_client
+            .docker
+            .create_exec(
+                container.id(),
+                CreateExecOptions::<&str> {
+                    attach_stdout: Some(true),
+                    attach_stderr: Some(true),
+                    cmd: Some(vec![
+                        "awslocal",
+                        "s3api",
+                        "create-bucket",
+                        "--bucket",
+                        &s3_bucket,
+                        "--region",
+                        &s3_region,
+                    ]),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        docker_client
+            .docker
+            .start_exec(&create_result.id, None)
+            .await?;
+
+        let s3_address = format!("http://{}:{}", address, Self::S3_CONTAINER_PORT);
+        let s3_host_port = container.get_host_port_ipv4(Self::S3_CONTAINER_PORT);
+        let s3_host_address = format!("http://127.0.0.1:{s3_host_port}");
+
+        tracing::info!(
+            s3_address,
+            s3_host_address,
+            "LocalStack container is running"
+        );
+        Ok(LocalStack {
+            container,
+            address,
+            s3_address,
+            s3_host_address,
+            s3_bucket,
+            s3_region,
+        })
+    }
+}
+
+pub struct LakeIndexer<'a> {
+    pub container: Container<'a, GenericImage>,
+    pub bucket_name: String,
+    pub region: String,
+    pub rpc_address: String,
+    pub rpc_host_address: String,
+}
+
+impl<'a> LakeIndexer<'a> {
+    pub const CONTAINER_RPC_PORT: u16 = 3030;
+
+    pub async fn run(
+        docker_client: &'a DockerClient,
+        network: &str,
+        s3_address: &str,
+        bucket_name: String,
+        region: String,
+    ) -> anyhow::Result<LakeIndexer<'a>> {
+        tracing::info!(
+            network,
+            s3_address,
+            bucket_name,
+            region,
+            "running NEAR Lake Indexer container..."
+        );
+
+        let image = GenericImage::new("near/near-lake-indexer", "latest")
+            .with_env_var("AWS_ACCESS_KEY_ID", "FAKE_LOCALSTACK_KEY_ID")
+            .with_env_var("AWS_SECRET_ACCESS_KEY", "FAKE_LOCALSTACK_ACCESS_KEY")
+            .with_wait_for(WaitFor::message_on_stderr("Starting Streamer"))
+            .with_exposed_port(Self::CONTAINER_RPC_PORT);
+        let image: RunnableImage<GenericImage> = (
+            image,
+            vec![
+                "--endpoint".to_string(),
+                s3_address.to_string(),
+                "--bucket".to_string(),
+                bucket_name.clone(),
+                "--region".to_string(),
+                region.clone(),
+                "--stream-while-syncing".to_string(),
+                "sync-from-latest".to_string(),
+            ],
+        )
+            .into();
+        let image = image.with_network(network);
+        let container = docker_client.cli.run(image);
+        let address = docker_client
+            .get_network_ip_address(&container, network)
+            .await?;
+        let rpc_address = format!("http://{}:{}", address, Self::CONTAINER_RPC_PORT);
+        let rpc_host_port = container.get_host_port_ipv4(Self::CONTAINER_RPC_PORT);
+        let rpc_host_address = format!("http://127.0.0.1:{rpc_host_port}");
+
+        tracing::info!(
+            bucket_name,
+            region,
+            rpc_address,
+            rpc_host_address,
+            "NEAR Lake Indexer container is running"
+        );
+        Ok(LakeIndexer {
+            container,
+            bucket_name,
+            region,
+            rpc_address,
+            rpc_host_address,
         })
     }
 }

--- a/integration-tests/src/multichain/containers.rs
+++ b/integration-tests/src/multichain/containers.rs
@@ -35,11 +35,16 @@ impl<'a> Node<'a> {
         tracing::info!(node_id, "running node container");
         let args = mpc_recovery_node::cli::Cli::Start {
             node_id: node_id.into(),
-            near_rpc: ctx.sandbox.local_address.clone(),
+            near_rpc: ctx.lake_indexer.rpc_host_address.clone(),
             mpc_contract_id: ctx.mpc_contract.id().clone(),
             account: account.clone(),
             account_sk: account_sk.to_string().parse()?,
             web_port: Self::CONTAINER_PORT,
+            indexer_options: mpc_recovery_node::indexer::Options {
+                s3_bucket: ctx.localstack.s3_host_address.clone(),
+                s3_region: ctx.localstack.s3_region.clone(),
+                start_block_height: 0,
+            },
         }
         .into_str_args();
         let image: GenericImage = GenericImage::new("near/mpc-recovery-node", "latest")

--- a/integration-tests/src/multichain/local.rs
+++ b/integration-tests/src/multichain/local.rs
@@ -24,11 +24,16 @@ impl Node {
         let web_port = util::pick_unused_port().await?;
         let cli = mpc_recovery_node::cli::Cli::Start {
             node_id: node_id.into(),
-            near_rpc: ctx.sandbox.local_address.clone(),
+            near_rpc: ctx.lake_indexer.rpc_host_address.clone(),
             mpc_contract_id: ctx.mpc_contract.id().clone(),
             account: account.clone(),
             account_sk: account_sk.to_string().parse()?,
             web_port,
+            indexer_options: mpc_recovery_node::indexer::Options {
+                s3_bucket: ctx.localstack.s3_host_address.clone(),
+                s3_region: ctx.localstack.s3_region.clone(),
+                start_block_height: 0,
+            },
         };
 
         let mpc_node_id = format!("multichain/{node_id}");

--- a/integration-tests/src/multichain/mod.rs
+++ b/integration-tests/src/multichain/mod.rs
@@ -2,7 +2,7 @@ pub mod containers;
 pub mod local;
 
 use crate::env::containers::DockerClient;
-use crate::{initialize_sandbox, SandboxCtx};
+use crate::{initialize_lake_indexer, LakeIndexerCtx};
 use mpc_contract::ParticipantInfo;
 use near_workspaces::network::Sandbox;
 use near_workspaces::{AccountId, Contract, Worker};
@@ -62,7 +62,8 @@ pub struct Context<'a> {
     pub docker_network: String,
     pub release: bool,
 
-    pub sandbox: crate::env::containers::Sandbox<'a>,
+    pub localstack: crate::env::containers::LocalStack<'a>,
+    pub lake_indexer: crate::env::containers::LakeIndexer<'a>,
     pub worker: Worker<Sandbox>,
     pub mpc_contract: Contract,
 }
@@ -71,7 +72,11 @@ pub async fn setup(docker_client: &DockerClient) -> anyhow::Result<Context<'_>> 
     let docker_network = NETWORK;
     docker_client.create_network(docker_network).await?;
 
-    let SandboxCtx { sandbox, worker } = initialize_sandbox(docker_client, NETWORK).await?;
+    let LakeIndexerCtx {
+        localstack,
+        lake_indexer,
+        worker,
+    } = initialize_lake_indexer(docker_client, docker_network).await?;
 
     let mpc_contract = worker
         .dev_deploy(include_bytes!(
@@ -84,7 +89,8 @@ pub async fn setup(docker_client: &DockerClient) -> anyhow::Result<Context<'_>> 
         docker_client,
         docker_network: docker_network.to_string(),
         release: true,
-        sandbox,
+        localstack,
+        lake_indexer,
         worker,
         mpc_contract,
     })

--- a/integration-tests/tests/lib.rs
+++ b/integration-tests/tests/lib.rs
@@ -72,7 +72,7 @@ where
     let docker_client = DockerClient::default();
     let nodes = mpc_recovery_integration_tests::multichain::run(nodes, &docker_client).await?;
 
-    let rpc_client = near_fetch::Client::new(&nodes.ctx().sandbox.local_address);
+    let rpc_client = near_fetch::Client::new(&nodes.ctx().lake_indexer.rpc_host_address);
     f(MultichainTestContext {
         nodes,
         rpc_client,

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -34,6 +34,9 @@ pub enum Cli {
         /// The web port for this server
         #[arg(long, env("MPC_RECOVERY_WEB_PORT"))]
         web_port: u16,
+        /// NEAR Lake Indexer options
+        #[clap(flatten)]
+        indexer_options: indexer::Options,
     },
 }
 
@@ -52,8 +55,9 @@ impl Cli {
                 account,
                 account_sk,
                 web_port,
+                indexer_options,
             } => {
-                vec![
+                let mut args = vec![
                     "start".to_string(),
                     "--node-id".to_string(),
                     u32::from(node_id).to_string(),
@@ -67,7 +71,9 @@ impl Cli {
                     account_sk.to_string(),
                     "--web-port".to_string(),
                     web_port.to_string(),
-                ]
+                ];
+                args.extend(indexer_options.into_str_args());
+                args
             }
         }
     }
@@ -94,6 +100,7 @@ pub fn run(cmd: Cli) -> anyhow::Result<()> {
             mpc_contract_id,
             account,
             account_sk,
+            indexer_options,
         } => {
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
@@ -142,7 +149,7 @@ pub fn run(cmd: Cli) -> anyhow::Result<()> {
 
                     anyhow::Ok(())
                 })?;
-            indexer::run(&near_rpc, mpc_contract_id)?;
+            indexer::run(&indexer_options, mpc_contract_id)?;
         }
     }
 


### PR DESCRIPTION
Relates to #346 

Sets up local instance of NEAR Lake Indexer that dumps all of the data to LocalStack S3 which is then consumed by the multichain node