### PR TITLE
Allow all actions in signing nodes

### DIFF
--- a/integration-tests/tests/mpc/negative.rs
+++ b/integration-tests/tests/mpc/negative.rs
@@ -64,14 +64,7 @@ async fn whitlisted_actions_test() -> anyhow::Result<()> {
         }
 
         // Performing blacklisted actions
-        let blacklisted_actions = vec![
-            ActionType::CreateAccount,
-            ActionType::DeployContract,
-            ActionType::FunctionCall,
-            ActionType::Transfer,
-            ActionType::Stake,
-            ActionType::DeleteAccount,
-        ];
+        let blacklisted_actions = vec![ActionType::DeleteAccount];
 
         for blacklisted_action in blacklisted_actions {
             ctx.leader_node
@@ -141,11 +134,11 @@ async fn whitlisted_actions_test() -> anyhow::Result<()> {
 }
 
 pub enum ActionType {
-    CreateAccount,
-    DeployContract,
-    FunctionCall,
-    Transfer,
-    Stake,
+    _CreateAccount,
+    _DeployContract,
+    _FunctionCall,
+    _Transfer,
+    _Stake,
     AddKey,
     DeleteKey,
     DeleteAccount,
@@ -153,16 +146,18 @@ pub enum ActionType {
 
 fn get_stub_delegate_action(action_type: ActionType) -> anyhow::Result<DelegateAction> {
     let action: Action = match action_type {
-        ActionType::CreateAccount => Action::CreateAccount(CreateAccountAction {}),
-        ActionType::DeployContract => Action::DeployContract(DeployContractAction { code: vec![] }),
-        ActionType::FunctionCall => Action::FunctionCall(FunctionCallAction {
+        ActionType::_CreateAccount => Action::CreateAccount(CreateAccountAction {}),
+        ActionType::_DeployContract => {
+            Action::DeployContract(DeployContractAction { code: vec![] })
+        }
+        ActionType::_FunctionCall => Action::FunctionCall(FunctionCallAction {
             method_name: "test".to_string(),
             args: vec![],
             gas: 0,
             deposit: 0,
         }),
-        ActionType::Transfer => Action::Transfer(TransferAction { deposit: 0 }),
-        ActionType::Stake => Action::Stake(StakeAction {
+        ActionType::_Transfer => Action::Transfer(TransferAction { deposit: 0 }),
+        ActionType::_Stake => Action::Stake(StakeAction {
             stake: 0,
             public_key: key::random_sk().public_key(),
         }),

--- a/mpc-recovery/src/error.rs
+++ b/mpc-recovery/src/error.rs
@@ -71,6 +71,8 @@ pub enum LeaderNodeError {
     RelayerError(#[from] RelayerError),
     #[error("recovery key can not be deleted: {0}")]
     RecoveryKeyCanNotBeDeleted(PublicKey),
+    #[error("action can not be performed, account deletion is not allowed")]
+    AccountDeletionIsNotAllowed,
     #[error("failed to retrieve recovery pk, check digest signature: {0}")]
     FailedToRetrieveRecoveryPk(anyhow::Error),
     #[error("timeout gathering sign node pks")]
@@ -94,6 +96,7 @@ impl LeaderNodeError {
             LeaderNodeError::RelayerError(_) => StatusCode::FAILED_DEPENDENCY,
             LeaderNodeError::TimeoutGatheringPublicKeys => StatusCode::INTERNAL_SERVER_ERROR,
             LeaderNodeError::RecoveryKeyCanNotBeDeleted(_) => StatusCode::BAD_REQUEST,
+            LeaderNodeError::AccountDeletionIsNotAllowed => StatusCode::BAD_REQUEST,
             LeaderNodeError::FailedToRetrieveRecoveryPk(_) => StatusCode::UNAUTHORIZED,
             LeaderNodeError::NetworkRejection(err) => {
                 err.status().unwrap_or(StatusCode::REQUEST_TIMEOUT)
@@ -117,8 +120,6 @@ pub enum SignNodeError {
     OidcTokenNotClaimed(OidcDigest),
     #[error("aggregate signing failed: {0}")]
     AggregateSigningFailed(#[from] AggregateSigningError),
-    #[error("This kind of action can not be performed")]
-    UnsupportedAction,
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -132,7 +133,6 @@ impl SignNodeError {
             Self::OidcTokenClaimedWithAnotherKey(_) => StatusCode::UNAUTHORIZED,
             Self::OidcTokenNotClaimed(_) => StatusCode::UNAUTHORIZED,
             Self::AggregateSigningFailed(err) => err.code(),
-            Self::UnsupportedAction => StatusCode::BAD_REQUEST,
             Self::Other(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/mpc-recovery/src/error.rs
+++ b/mpc-recovery/src/error.rs
@@ -72,7 +72,7 @@ pub enum LeaderNodeError {
     #[error("recovery key can not be deleted: {0}")]
     RecoveryKeyCanNotBeDeleted(PublicKey),
     #[error("action can not be performed, account deletion is not allowed")]
-    AccountDeletionIsNotAllowed,
+    AccountDeletionUnsupported,
     #[error("failed to retrieve recovery pk, check digest signature: {0}")]
     FailedToRetrieveRecoveryPk(anyhow::Error),
     #[error("timeout gathering sign node pks")]
@@ -96,7 +96,7 @@ impl LeaderNodeError {
             LeaderNodeError::RelayerError(_) => StatusCode::FAILED_DEPENDENCY,
             LeaderNodeError::TimeoutGatheringPublicKeys => StatusCode::INTERNAL_SERVER_ERROR,
             LeaderNodeError::RecoveryKeyCanNotBeDeleted(_) => StatusCode::BAD_REQUEST,
-            LeaderNodeError::AccountDeletionIsNotAllowed => StatusCode::BAD_REQUEST,
+            LeaderNodeError::AccountDeletionUnsupported => StatusCode::BAD_REQUEST,
             LeaderNodeError::FailedToRetrieveRecoveryPk(_) => StatusCode::UNAUTHORIZED,
             LeaderNodeError::NetworkRejection(err) => {
                 err.status().unwrap_or(StatusCode::REQUEST_TIMEOUT)

--- a/mpc-recovery/src/leader_node/mod.rs
+++ b/mpc-recovery/src/leader_node/mod.rs
@@ -539,7 +539,7 @@ async fn process_sign(
         })
         .collect();
 
-    if delete_account_actions.len() > 0 {
+    if !delete_account_actions.is_empty() {
         tracing::error!("Account deletion is not allowed");
         Err(LeaderNodeError::AccountDeletionIsNotAllowed)?;
     }

--- a/mpc-recovery/src/leader_node/mod.rs
+++ b/mpc-recovery/src/leader_node/mod.rs
@@ -541,7 +541,7 @@ async fn process_sign(
 
     if !delete_account_actions.is_empty() {
         tracing::error!("Account deletion is not allowed");
-        Err(LeaderNodeError::AccountDeletionIsNotAllowed)?;
+        Err(LeaderNodeError::AccountDeletionUnsupported)?;
     }
 
     // Get MPC signature

--- a/mpc-recovery/src/leader_node/mod.rs
+++ b/mpc-recovery/src/leader_node/mod.rs
@@ -31,7 +31,7 @@ use borsh::BorshDeserialize;
 use curv::elliptic::curves::{Ed25519, Point};
 use near_fetch::signer::KeyRotatingSigner;
 use near_primitives::delegate_action::{DelegateAction, NonDelegateAction};
-use near_primitives::transaction::{Action, DeleteKeyAction};
+use near_primitives::transaction::{Action, DeleteAccountAction, DeleteKeyAction};
 use near_primitives::types::AccountId;
 use prometheus::{Encoder, TextEncoder};
 use std::net::SocketAddr;
@@ -527,6 +527,21 @@ async fn process_sign(
                 delete_key_action.public_key.clone(),
             ))?;
         }
+    }
+
+    // Prevent account deletion
+    // Note: we can allow account deletionn once we sync that with relayer. With current logic user will not be able to create another account.
+    let delete_account_actions: Vec<&DeleteAccountAction> = requested_actions
+        .iter()
+        .filter_map(|action| match action {
+            Action::DeleteAccount(delete_account_action) => Some(delete_account_action),
+            _ => None,
+        })
+        .collect();
+
+    if delete_account_actions.len() > 0 {
+        tracing::error!("Account deletion is not allowed");
+        Err(LeaderNodeError::AccountDeletionIsNotAllowed)?;
     }
 
     // Get MPC signature

--- a/mpc-recovery/src/sign_node/mod.rs
+++ b/mpc-recovery/src/sign_node/mod.rs
@@ -21,10 +21,8 @@ use borsh::BorshSerialize;
 use curv::elliptic::curves::{Ed25519, Point};
 use multi_party_eddsa::protocols::{self, ExpandedKeyPair};
 
-use near_primitives::delegate_action::NonDelegateAction;
 use near_primitives::hash::hash;
 use near_primitives::signable_message::{SignableMessage, SignableMessageType};
-use near_primitives::transaction::{Action, AddKeyAction, DeleteKeyAction};
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -265,30 +263,6 @@ async fn process_commit(
                     return Err(SignNodeError::Other(e));
                 }
             };
-
-            // Restrict certain types of DelegateActions
-            let requested_delegate_actions: &Vec<NonDelegateAction> =
-                &request.delegate_action.actions;
-
-            let requested_actions: &Vec<Action> = &requested_delegate_actions
-                .iter()
-                .map(|non_delegate_action| Action::from(non_delegate_action.clone()))
-                .collect();
-
-            for action in requested_actions {
-                match action {
-                    Action::AddKey(AddKeyAction { .. }) => {
-                        tracing::debug!("AddKeyAction is supported");
-                    }
-                    Action::DeleteKey(DeleteKeyAction { .. }) => {
-                        tracing::debug!("DeleteKeyAction is supported");
-                    }
-                    _ => {
-                        tracing::error!("Unsupported action: {:?}", action);
-                        return Err(SignNodeError::UnsupportedAction);
-                    }
-                }
-            }
 
             // Get user credentials
             let internal_account_id = oidc_token_claims.get_internal_account_id();


### PR DESCRIPTION
- Action type check deleted on the signing node level
- Account deletion prevented on the leader node level