### PR TITLE
chore: Only run integration tests if specific folders change

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - develop
   pull_request:
+    paths:
+      - integration-tests/**
+      - mpc-recovery/**
+      - load-tests/**
+      - test-oidc-provider/**
 
 jobs:
   integrations:

--- a/.github/workflows/multichain-integration.yml
+++ b/.github/workflows/multichain-integration.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - develop
   pull_request:
+    paths:
+      - integration-tests/**
+      - node/**
+      - contract/**
 
 env:
   RUSTFLAGS: -D warnings


### PR DESCRIPTION
Thought this minor thing could save a couple compute and wait cycles. Now we're only running integration tests if specific code folders change