### PR TITLE
fix: make Lake indexer work with macos

### DIFF
--- a/integration-tests/src/env/containers.rs
+++ b/integration-tests/src/env/containers.rs
@@ -608,7 +608,7 @@ impl<'a> LakeIndexer<'a> {
 
         let image = GenericImage::new(
             "ghcr.io/near/near-lake-indexer",
-            "e6519c922435f3d18b5f2ddac5d1ec171ef4dd6b",
+            "18ef24922fd7b5b8985ea793fdf7a939e57216ba",
         )
         .with_env_var("AWS_ACCESS_KEY_ID", "FAKE_LOCALSTACK_KEY_ID")
         .with_env_var("AWS_SECRET_ACCESS_KEY", "FAKE_LOCALSTACK_ACCESS_KEY")

--- a/integration-tests/src/env/containers.rs
+++ b/integration-tests/src/env/containers.rs
@@ -553,8 +553,16 @@ impl<'a> LocalStack<'a> {
             .await?;
 
         let s3_address = format!("http://{}:{}", address, Self::S3_CONTAINER_PORT);
-        let s3_host_port = container.get_host_port_ipv6(Self::S3_CONTAINER_PORT);
-        let s3_host_address = format!("http://[::1]:{s3_host_port}");
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        let s3_host_address = {
+            let s3_host_port = container.get_host_port_ipv4(Self::S3_CONTAINER_PORT);
+            format!("http://127.0.0.1:{s3_host_port}")
+        };
+        #[cfg(target_arch = "x86_64")]
+        let s3_host_address = {
+            let s3_host_port = container.get_host_port_ipv6(Self::S3_CONTAINER_PORT);
+            format!("http://[::1]:{s3_host_port}");
+        };
 
         tracing::info!(
             s3_address,

--- a/integration-tests/src/env/containers.rs
+++ b/integration-tests/src/env/containers.rs
@@ -561,7 +561,7 @@ impl<'a> LocalStack<'a> {
         #[cfg(target_arch = "x86_64")]
         let s3_host_address = {
             let s3_host_port = container.get_host_port_ipv6(Self::S3_CONTAINER_PORT);
-            format!("http://[::1]:{s3_host_port}");
+            format!("http://[::1]:{s3_host_port}")
         };
 
         tracing::info!(


### PR DESCRIPTION
Trying to make Lake indexer work on macos. This fixes the first issue, but now I am seeing:
```
2023-11-29T02:07:23.918329Z ERROR ThreadId(09) mpc_recovery_node::protocol:
could not fetch contract's state: handler error:
[Function call returned an error: wasm execution failed with error:
  CompilationError(WasmerCompileError {
      msg: "The target x86_64 without AVX is not yet supported (see https://docs.wasmer.io/ecosystem/wasmer/wasmer-features)"
  })
]
```

This *probably* means we need to rebuild Lake indexer image on macos and conditionally use that one when host machine is ARM-based