### PR TITLE
fix: ignore RUSTSEC-2023-0071

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -51,4 +51,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2023-0052 --ignore RUSTSEC-2022-0093
+          args: --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2023-0052 --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2023-0071


### PR DESCRIPTION
Ignoring newly discovered vulnerability:
```
Crate:     rsa
Version:   0.8.2
Title:     Marvin Attack: potential key recovery through timing sidechannels
Date:      2023-11-22
ID:        RUSTSEC-2023-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2023-0071
Solution:  No fixed upgrade is available!
Dependency tree:
rsa 0.8.2
└── mpc-recovery 0.1.0
    ├── mpc-recovery-integration-tests 0.1.0
    └── load-tests 0.1.0
```

I don't think this matters for us as we are using `rsa` purely to validate external JWT tokens. In any case, there is no fix for now.