### PR TITLE
fix: decrypt message during joining phase

### DIFF
--- a/integration-tests/tests/lib.rs
+++ b/integration-tests/tests/lib.rs
@@ -212,6 +212,7 @@ mod check {
 
 mod wait_for {
     use crate::MultichainTestContext;
+    use anyhow::Context;
     use backon::ExponentialBuilder;
     use backon::Retryable;
     use mpc_contract::ProtocolContractState;
@@ -241,6 +242,7 @@ mod wait_for {
         is_running
             .retry(&ExponentialBuilder::default().with_max_times(6))
             .await
+            .with_context(|| format!("mpc nodes did not reach epoch '{epoch}' before deadline"))
     }
 
     pub async fn has_at_least_triples<'a>(
@@ -270,6 +272,7 @@ mod wait_for {
         is_enough_triples
             .retry(&ExponentialBuilder::default().with_max_times(6))
             .await
+            .with_context(|| format!("mpc node '{id}' failed to generate '{expected_triple_count}' triples before deadline"))
     }
 
     pub async fn has_at_least_presignatures<'a>(
@@ -299,6 +302,7 @@ mod wait_for {
         is_enough_presignatures
             .retry(&ExponentialBuilder::default().with_max_times(6))
             .await
+            .with_context(|| format!("mpc node '{id}' failed to generate '{expected_presignature_count}' presignatures before deadline"))
     }
 
     pub async fn has_response<'a>(
@@ -316,6 +320,9 @@ mod wait_for {
         is_enough_presignatures
             .retry(&ExponentialBuilder::default().with_max_times(8))
             .await
+            .with_context(|| {
+                format!("mpc failed to respond to receipt id '{receipt_id}' before deadline")
+            })
     }
 }
 

--- a/node/src/protocol/consensus.rs
+++ b/node/src/protocol/consensus.rs
@@ -87,7 +87,10 @@ impl ConsensusProtocol for StartedState {
                                 epoch,
                                 contract_state.epoch
                             );
-                            Ok(NodeState::Joining(JoiningState { public_key }))
+                            Ok(NodeState::Joining(JoiningState {
+                                participants: contract_state.participants,
+                                public_key,
+                            }))
                         }
                         Ordering::Less => Err(ConsensusError::EpochRollback),
                         Ordering::Equal => {
@@ -128,7 +131,10 @@ impl ConsensusProtocol for StartedState {
                                     )),
                                 }))
                             } else {
-                                Ok(NodeState::Joining(JoiningState { public_key }))
+                                Ok(NodeState::Joining(JoiningState {
+                                    participants: contract_state.participants,
+                                    public_key,
+                                }))
                             }
                         }
                     }
@@ -144,7 +150,10 @@ impl ConsensusProtocol for StartedState {
                                 epoch,
                                 contract_state.old_epoch
                             );
-                            Ok(NodeState::Joining(JoiningState { public_key }))
+                            Ok(NodeState::Joining(JoiningState {
+                                participants: contract_state.old_participants,
+                                public_key,
+                            }))
                         }
                         Ordering::Less => Err(ConsensusError::EpochRollback),
                         Ordering::Equal => {
@@ -177,9 +186,11 @@ impl ConsensusProtocol for StartedState {
                     }
                 }
                 ProtocolState::Running(contract_state) => Ok(NodeState::Joining(JoiningState {
+                    participants: contract_state.participants,
                     public_key: contract_state.public_key,
                 })),
                 ProtocolState::Resharing(contract_state) => Ok(NodeState::Joining(JoiningState {
+                    participants: contract_state.old_participants,
                     public_key: contract_state.public_key,
                 })),
             },
@@ -203,6 +214,7 @@ impl ConsensusProtocol for GeneratingState {
                 if contract_state.epoch > 0 {
                     tracing::warn!("contract has already changed epochs, trying to rejoin as a new participant");
                     return Ok(NodeState::Joining(JoiningState {
+                        participants: contract_state.participants,
                         public_key: contract_state.public_key,
                     }));
                 }
@@ -219,6 +231,7 @@ impl ConsensusProtocol for GeneratingState {
                 if contract_state.old_epoch > 0 {
                     tracing::warn!("contract has already changed epochs, trying to rejoin as a new participant");
                     return Ok(NodeState::Joining(JoiningState {
+                        participants: contract_state.old_participants,
                         public_key: contract_state.public_key,
                     }));
                 }
@@ -272,6 +285,7 @@ impl ConsensusProtocol for WaitingForConsensusState {
                             contract_state.epoch
                         );
                     Ok(NodeState::Joining(JoiningState {
+                        participants: contract_state.participants,
                         public_key: contract_state.public_key,
                     }))
                 }
@@ -339,6 +353,7 @@ impl ConsensusProtocol for WaitingForConsensusState {
                             contract_state.old_epoch
                         );
                         Ok(NodeState::Joining(JoiningState {
+                            participants: contract_state.old_participants,
                             public_key: contract_state.public_key,
                         }))
                     }
@@ -387,6 +402,7 @@ impl ConsensusProtocol for RunningState {
                             contract_state.epoch
                         );
                     Ok(NodeState::Joining(JoiningState {
+                        participants: contract_state.participants,
                         public_key: contract_state.public_key,
                     }))
                 }
@@ -414,6 +430,7 @@ impl ConsensusProtocol for RunningState {
                             contract_state.old_epoch
                         );
                         Ok(NodeState::Joining(JoiningState {
+                            participants: contract_state.old_participants,
                             public_key: contract_state.public_key,
                         }))
                     }
@@ -454,6 +471,7 @@ impl ConsensusProtocol for ResharingState {
                             contract_state.epoch
                         );
                         Ok(NodeState::Joining(JoiningState {
+                            participants: contract_state.participants,
                             public_key: contract_state.public_key,
                         }))
                     }
@@ -482,6 +500,7 @@ impl ConsensusProtocol for ResharingState {
                             contract_state.old_epoch
                         );
                         Ok(NodeState::Joining(JoiningState {
+                            participants: contract_state.old_participants,
                             public_key: contract_state.public_key,
                         }))
                     }

--- a/node/src/protocol/state.rs
+++ b/node/src/protocol/state.rs
@@ -98,7 +98,17 @@ impl ResharingState {
 
 #[derive(Clone)]
 pub struct JoiningState {
+    pub participants: BTreeMap<Participant, ParticipantInfo>,
     pub public_key: PublicKey,
+}
+
+impl JoiningState {
+    pub fn fetch_participant(
+        &self,
+        p: &Participant,
+    ) -> Result<&ParticipantInfo, CryptographicError> {
+        fetch_participant(p, &self.participants)
+    }
 }
 
 #[derive(Clone, Default)]
@@ -124,6 +134,7 @@ impl NodeState {
             NodeState::Generating(state) => state.fetch_participant(p),
             NodeState::WaitingForConsensus(state) => state.fetch_participant(p),
             NodeState::Resharing(state) => state.fetch_participant(p),
+            NodeState::Joining(state) => state.fetch_participant(p),
             _ => Err(CryptographicError::UnknownParticipant(*p)),
         }
     }


### PR DESCRIPTION
There is a race condition during resharing where a message can arrive before a joining realizes the contract has moved to `Resharing` phase. With this fix it will at least be able to decrypt the message and store it in the queue.