### PR TITLE
fix: Format error so context can show full chain

### DIFF
--- a/node/src/web/error.rs
+++ b/node/src/web/error.rs
@@ -42,7 +42,7 @@ impl axum::response::IntoResponse for Error {
         let status = self.status();
         let message = match self {
             Error::JsonExtractorRejection(json_rejection) => json_rejection.body_text(),
-            err => err.to_string(),
+            err => format!("{err:?}"),
         };
 
         (status, axum::Json(message)).into_response()


### PR DESCRIPTION
`to_string()` only shows the `.(with_)context` message for anyhow messages but not the full nested error.

For example:
```rs
 let x = anyhow::anyhow!("first");
 println!("{:?}", x.context("second").to_string());
```
will only print `second`