### PR TITLE
chore: cleanup protocol types

### DIFF
--- a/node/src/protocol/message.rs
+++ b/node/src/protocol/message.rs
@@ -210,9 +210,6 @@ impl MessageHandler for RunningState {
         let mut triple_manager = self.triple_manager.write().await;
         for (id, queue) in queue.triple_bins.entry(self.epoch).or_default() {
             if let Some(protocol) = triple_manager.get_or_generate(*id)? {
-                let mut protocol = protocol
-                    .write()
-                    .map_err(|err| MessageHandleError::SyncError(err.to_string()))?;
                 while let Some(message) = queue.pop_front() {
                     protocol.message(message.from, message.data);
                 }

--- a/node/src/protocol/message.rs
+++ b/node/src/protocol/message.rs
@@ -228,12 +228,7 @@ impl MessageHandler for RunningState {
                     &self.public_key,
                     &self.private_share,
                 ) {
-                    Ok(protocol) => {
-                        let mut protocol = protocol
-                            .write()
-                            .map_err(|err| MessageHandleError::SyncError(err.to_string()))?;
-                        protocol.message(message.from, message.data)
-                    }
+                    Ok(protocol) => protocol.message(message.from, message.data),
                     Err(presignature::GenerationError::AlreadyGenerated) => {
                         tracing::info!(id, "presignature already generated, nothing left to do")
                     }

--- a/node/src/protocol/message.rs
+++ b/node/src/protocol/message.rs
@@ -277,12 +277,7 @@ impl MessageHandler for RunningState {
                     message.delta,
                     &mut presignature_manager,
                 )? {
-                    Some(protocol) => {
-                        let mut protocol = protocol
-                            .write()
-                            .map_err(|err| MessageHandleError::SyncError(err.to_string()))?;
-                        protocol.message(message.from, message.data)
-                    }
+                    Some(protocol) => protocol.message(message.from, message.data),
                     None => {
                         // Store the message until we are ready to process it
                         leftover_messages.push(message)

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -12,7 +12,6 @@ pub type KeygenProtocol = Arc<RwLock<dyn Protocol<Output = KeygenOutput<Secp256k
 pub type ReshareProtocol = Arc<RwLock<dyn Protocol<Output = SecretKeyShare> + Send + Sync>>;
 pub type TripleProtocol =
     Box<dyn Protocol<Output = TripleGenerationOutput<Secp256k1>> + Send + Sync>;
-pub type PresignatureProtocol =
-    Arc<std::sync::RwLock<dyn Protocol<Output = PresignOutput<Secp256k1>> + Send + Sync>>;
+pub type PresignatureProtocol = Box<dyn Protocol<Output = PresignOutput<Secp256k1>> + Send + Sync>;
 pub type SignatureProtocol =
     Arc<std::sync::RwLock<dyn Protocol<Output = FullSignature<Secp256k1>> + Send + Sync>>;

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -11,7 +11,7 @@ pub type PublicKey = <Secp256k1 as CurveArithmetic>::AffinePoint;
 pub type KeygenProtocol = Arc<RwLock<dyn Protocol<Output = KeygenOutput<Secp256k1>> + Send + Sync>>;
 pub type ReshareProtocol = Arc<RwLock<dyn Protocol<Output = SecretKeyShare> + Send + Sync>>;
 pub type TripleProtocol =
-    Arc<std::sync::RwLock<dyn Protocol<Output = TripleGenerationOutput<Secp256k1>> + Send + Sync>>;
+    Box<dyn Protocol<Output = TripleGenerationOutput<Secp256k1>> + Send + Sync>;
 pub type PresignatureProtocol =
     Arc<std::sync::RwLock<dyn Protocol<Output = PresignOutput<Secp256k1>> + Send + Sync>>;
 pub type SignatureProtocol =

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -13,5 +13,4 @@ pub type ReshareProtocol = Arc<RwLock<dyn Protocol<Output = SecretKeyShare> + Se
 pub type TripleProtocol =
     Box<dyn Protocol<Output = TripleGenerationOutput<Secp256k1>> + Send + Sync>;
 pub type PresignatureProtocol = Box<dyn Protocol<Output = PresignOutput<Secp256k1>> + Send + Sync>;
-pub type SignatureProtocol =
-    Arc<std::sync::RwLock<dyn Protocol<Output = FullSignature<Secp256k1>> + Send + Sync>>;
+pub type SignatureProtocol = Box<dyn Protocol<Output = FullSignature<Secp256k1>> + Send + Sync>;


### PR DESCRIPTION
The `{Triple, Presignature, Signature}Protocol` seems to not need to be behind a `Arc<RwLock<_>>` since they're only ever written to and never read and we always have a mutable reference in the crypto loop anyways. This also simplifies the code a bit