### PR TITLE
feat: Added the ability to refresh the protocol on failures

### DIFF
--- a/node/src/protocol/consensus.rs
+++ b/node/src/protocol/consensus.rs
@@ -9,7 +9,7 @@ use crate::protocol::signature::SignatureManager;
 use crate::protocol::state::{GeneratingState, ResharingState};
 use crate::protocol::triple::TripleManager;
 use crate::storage::{SecretNodeStorageBox, SecretStorageError};
-use crate::types::{SecretKeyShare, KeygenProtocol};
+use crate::types::{KeygenProtocol, SecretKeyShare};
 use crate::util::AffinePointExt;
 use crate::{http_client, rpc_client};
 use async_trait::async_trait;

--- a/node/src/protocol/consensus.rs
+++ b/node/src/protocol/consensus.rs
@@ -9,12 +9,11 @@ use crate::protocol::signature::SignatureManager;
 use crate::protocol::state::{GeneratingState, ResharingState};
 use crate::protocol::triple::TripleManager;
 use crate::storage::{SecretNodeStorageBox, SecretStorageError};
-use crate::types::{KeygenProtocol, SecretKeyShare};
+use crate::types::{KeygenProtocol, ReshareProtocol, SecretKeyShare};
 use crate::util::AffinePointExt;
 use crate::{http_client, rpc_client};
 use async_trait::async_trait;
 use cait_sith::protocol::{InitializationError, Participant};
-use k256::Secp256k1;
 use mpc_keys::hpke;
 use near_crypto::InMemorySigner;
 use near_primitives::transaction::{Action, FunctionCallAction};
@@ -684,30 +683,14 @@ async fn start_resharing<C: ConsensusCtx>(
         .new_participants
         .find_participant(ctx.my_account_id())
         .unwrap();
-    let protocol = cait_sith::reshare::<Secp256k1>(
-        &contract_state
-            .old_participants
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>(),
-        contract_state.threshold,
-        &contract_state
-            .new_participants
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>(),
-        contract_state.threshold,
-        me,
-        private_share,
-        contract_state.public_key,
-    )?;
+    let protocol = ReshareProtocol::new(private_share, me, &contract_state)?;
     Ok(NodeState::Resharing(ResharingState {
         old_epoch: contract_state.old_epoch,
         old_participants: contract_state.old_participants,
         new_participants: contract_state.new_participants,
         threshold: contract_state.threshold,
         public_key: contract_state.public_key,
-        protocol: Arc::new(RwLock::new(protocol)),
+        protocol,
         messages: Default::default(),
     }))
 }

--- a/node/src/protocol/consensus.rs
+++ b/node/src/protocol/consensus.rs
@@ -9,7 +9,7 @@ use crate::protocol::signature::SignatureManager;
 use crate::protocol::state::{GeneratingState, ResharingState};
 use crate::protocol::triple::TripleManager;
 use crate::storage::{SecretNodeStorageBox, SecretStorageError};
-use crate::types::SecretKeyShare;
+use crate::types::{SecretKeyShare, KeygenProtocol};
 use crate::util::AffinePointExt;
 use crate::{http_client, rpc_client};
 use async_trait::async_trait;
@@ -186,7 +186,7 @@ impl ConsensusProtocol for StartedState {
                                 "starting key generation as a part of the participant set"
                             );
                             let participants = contract_state.participants;
-                            let protocol = cait_sith::keygen::<Secp256k1>(
+                            let protocol = KeygenProtocol::new(
                                 &participants.keys().cloned().collect::<Vec<_>>(),
                                 me,
                                 contract_state.threshold,
@@ -194,7 +194,7 @@ impl ConsensusProtocol for StartedState {
                             Ok(NodeState::Generating(GeneratingState {
                                 participants,
                                 threshold: contract_state.threshold,
-                                protocol: Arc::new(RwLock::new(protocol)),
+                                protocol,
                                 messages: Default::default(),
                             }))
                         }

--- a/node/src/protocol/cryptography.rs
+++ b/node/src/protocol/cryptography.rs
@@ -77,8 +77,8 @@ impl CryptographicProtocol for GeneratingState {
                 Ok(action) => action,
                 Err(err) => {
                     drop(protocol);
-                    if let Err(err) = self.protocol.refresh().await {
-                        tracing::warn!(?err, "unable to refresh keygen protocol");
+                    if let Err(refresh_err) = self.protocol.refresh().await {
+                        tracing::warn!(?refresh_err, "unable to refresh keygen protocol");
                     }
                     return Err(err)?;
                 }
@@ -193,7 +193,16 @@ impl CryptographicProtocol for ResharingState {
         tracing::info!("progressing key reshare");
         let mut protocol = self.protocol.write().await;
         loop {
-            let action = protocol.poke()?;
+            let action = match protocol.poke() {
+                Ok(action) => action,
+                Err(err) => {
+                    drop(protocol);
+                    if let Err(refresh_err) = self.protocol.refresh().await {
+                        tracing::warn!(?refresh_err, "unable to refresh reshare protocol");
+                    }
+                    return Err(err)?;
+                }
+            };
             match action {
                 Action::Wait => {
                     drop(protocol);

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -1,16 +1,59 @@
 use std::sync::Arc;
 
+use cait_sith::protocol::{InitializationError, Participant};
 use cait_sith::triples::TripleGenerationOutput;
 use cait_sith::{protocol::Protocol, KeygenOutput};
 use cait_sith::{FullSignature, PresignOutput};
 use k256::{elliptic_curve::CurveArithmetic, Secp256k1};
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, RwLockWriteGuard};
 
 pub type SecretKeyShare = <Secp256k1 as CurveArithmetic>::Scalar;
 pub type PublicKey = <Secp256k1 as CurveArithmetic>::AffinePoint;
-pub type KeygenProtocol = Arc<RwLock<dyn Protocol<Output = KeygenOutput<Secp256k1>> + Send + Sync>>;
 pub type ReshareProtocol = Arc<RwLock<dyn Protocol<Output = SecretKeyShare> + Send + Sync>>;
 pub type TripleProtocol =
     Box<dyn Protocol<Output = TripleGenerationOutput<Secp256k1>> + Send + Sync>;
 pub type PresignatureProtocol = Box<dyn Protocol<Output = PresignOutput<Secp256k1>> + Send + Sync>;
 pub type SignatureProtocol = Box<dyn Protocol<Output = FullSignature<Secp256k1>> + Send + Sync>;
+
+#[derive(Clone)]
+pub struct KeygenProtocol {
+    me: Participant,
+    threshold: usize,
+    participants: Vec<Participant>,
+    protocol: Arc<RwLock<Box<dyn Protocol<Output = KeygenOutput<Secp256k1>> + Send + Sync>>>,
+}
+
+impl KeygenProtocol {
+    pub fn new(
+        participants: &[Participant],
+        me: Participant,
+        threshold: usize,
+    ) -> Result<Self, InitializationError> {
+        Ok(Self {
+            threshold,
+            me,
+            participants: participants.into(),
+            protocol: Arc::new(RwLock::new(Box::new(cait_sith::keygen::<Secp256k1>(
+                &participants,
+                me,
+                threshold,
+            )?))),
+        })
+    }
+
+    pub async fn refresh(&mut self) -> Result<(), InitializationError> {
+        *self.write().await = Box::new(cait_sith::keygen::<Secp256k1>(
+            &self.participants,
+            self.me,
+            self.threshold,
+        )?);
+        Ok(())
+    }
+
+    pub async fn write(
+        &self,
+    ) -> RwLockWriteGuard<'_, Box<dyn Protocol<Output = KeygenOutput<Secp256k1>> + Send + Sync>>
+    {
+        self.protocol.write().await
+    }
+}

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -7,9 +7,10 @@ use cait_sith::{FullSignature, PresignOutput};
 use k256::{elliptic_curve::CurveArithmetic, Secp256k1};
 use tokio::sync::{RwLock, RwLockWriteGuard};
 
+use crate::protocol::contract::ResharingContractState;
+
 pub type SecretKeyShare = <Secp256k1 as CurveArithmetic>::Scalar;
 pub type PublicKey = <Secp256k1 as CurveArithmetic>::AffinePoint;
-pub type ReshareProtocol = Arc<RwLock<dyn Protocol<Output = SecretKeyShare> + Send + Sync>>;
 pub type TripleProtocol =
     Box<dyn Protocol<Output = TripleGenerationOutput<Secp256k1>> + Send + Sync>;
 pub type PresignatureProtocol = Box<dyn Protocol<Output = PresignOutput<Secp256k1>> + Send + Sync>;
@@ -54,6 +55,74 @@ impl KeygenProtocol {
         &self,
     ) -> RwLockWriteGuard<'_, Box<dyn Protocol<Output = KeygenOutput<Secp256k1>> + Send + Sync>>
     {
+        self.protocol.write().await
+    }
+}
+
+#[derive(Clone)]
+pub struct ReshareProtocol {
+    old_participants: Vec<Participant>,
+    new_participants: Vec<Participant>,
+    me: Participant,
+    threshold: usize,
+    private_share: Option<SecretKeyShare>,
+    protocol: Arc<RwLock<Box<dyn Protocol<Output = SecretKeyShare> + Send + Sync>>>,
+    root_pk: PublicKey,
+}
+
+impl ReshareProtocol {
+    pub fn new(
+        private_share: Option<SecretKeyShare>,
+        me: Participant,
+        contract_state: &ResharingContractState,
+    ) -> Result<Self, InitializationError> {
+        let old_participants = contract_state
+            .old_participants
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let new_participants = contract_state
+            .new_participants
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+
+        Ok(Self {
+            protocol: Arc::new(RwLock::new(Box::new(cait_sith::reshare::<Secp256k1>(
+                &old_participants,
+                contract_state.threshold,
+                &new_participants,
+                contract_state.threshold,
+                me,
+                private_share,
+                contract_state.public_key,
+            )?))),
+            private_share,
+            me,
+            threshold: contract_state.threshold,
+            old_participants,
+            new_participants,
+            root_pk: contract_state.public_key,
+        })
+    }
+
+    pub async fn refresh(&mut self) -> Result<(), InitializationError> {
+        *self.write().await = Box::new(cait_sith::reshare::<Secp256k1>(
+            &self.old_participants,
+            self.threshold,
+            &self.new_participants,
+            self.threshold,
+            self.me,
+            self.private_share,
+            self.root_pk,
+        )?);
+        Ok(())
+    }
+
+    pub async fn write(
+        &self,
+    ) -> RwLockWriteGuard<'_, Box<dyn Protocol<Output = SecretKeyShare> + Send + Sync>> {
         self.protocol.write().await
     }
 }

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -34,7 +34,7 @@ impl KeygenProtocol {
             me,
             participants: participants.into(),
             protocol: Arc::new(RwLock::new(Box::new(cait_sith::keygen::<Secp256k1>(
-                &participants,
+                participants,
                 me,
                 threshold,
             )?))),


### PR DESCRIPTION
This adds the ability to refresh a protocol when it fails. Protocols currently remain in a bad state if they fail, so this will generate a new one in the case that happens. Also, note that the main loop transactional nature where state is copied and then mutated doesn't actually protect the protocols since they are non-copyable and we want to maintain protocol state between loop iterations until they are complete or error out. And on the case of erroring out, we will refresh the protocol with a new one.

Currently only added this for `KeygenProtocol` but if this looks good, I'll do it for the rest too.