### PR TITLE
fix: easier fix for ci tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3975,7 +3975,6 @@ dependencies = [
  "near-lake-framework",
  "near-lake-primitives",
  "near-primitives 0.17.0",
- "near-sdk",
  "rand 0.8.5",
  "reqwest",
  "serde",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -42,7 +42,6 @@ near-fetch = "0.0.12"
 near-lake-framework = { git = "https://github.com/near/near-lake-framework-rs.git", branch = "daniyar/upgrade-sdk" }
 near-lake-primitives = { git = "https://github.com/near/near-lake-framework-rs.git", branch = "daniyar/upgrade-sdk" }
 near-primitives = "0.17"
-near-sdk = "5.0.0-alpha.1"
 
 mpc-contract = { path = "../contract" }
 mpc-keys = { path = "../keys" }

--- a/node/src/protocol/contract/primitives.rs
+++ b/node/src/protocol/contract/primitives.rs
@@ -223,9 +223,7 @@ impl From<mpc_contract::primitives::PkVotes> for PkVotes {
                         ),
                         participants
                             .into_iter()
-                            .map(|acc_id: near_sdk::AccountId| {
-                                AccountId::from_str(acc_id.as_ref()).unwrap()
-                            })
+                            .map(|acc_id| AccountId::from_str(acc_id.as_ref()).unwrap())
                             .collect(),
                     )
                 })
@@ -256,9 +254,7 @@ impl From<mpc_contract::primitives::Votes> for Votes {
                         AccountId::from_str(account_id.as_ref()).unwrap(),
                         participants
                             .into_iter()
-                            .map(|acc_id: near_sdk::AccountId| {
-                                AccountId::from_str(acc_id.as_ref()).unwrap()
-                            })
+                            .map(|acc_id| AccountId::from_str(acc_id.as_ref()).unwrap())
                             .collect(),
                     )
                 })

--- a/node/src/util.rs
+++ b/node/src/util.rs
@@ -7,14 +7,15 @@ pub trait NearPublicKeyExt {
     fn into_affine_point(self) -> PublicKey;
 }
 
-impl NearPublicKeyExt for near_sdk::PublicKey {
-    fn into_affine_point(self) -> PublicKey {
-        let mut bytes = self.into_bytes();
-        bytes[0] = 0x04;
-        let point = EncodedPoint::from_bytes(bytes).unwrap();
-        PublicKey::from_encoded_point(&point).unwrap()
-    }
-}
+// TODO: fix this when we update all near dependencies
+// impl NearPublicKeyExt for near_sdk::PublicKey {
+//     fn into_affine_point(self) -> PublicKey {
+//         let mut bytes = self.into_bytes();
+//         bytes[0] = 0x04;
+//         let point = EncodedPoint::from_bytes(bytes).unwrap();
+//         PublicKey::from_encoded_point(&point).unwrap()
+//     }
+// }
 
 impl NearPublicKeyExt for near_crypto::Secp256K1PublicKey {
     fn into_affine_point(self) -> PublicKey {


### PR DESCRIPTION
Hopefully this one fixes the CI test more easily. Only needed to exclude near-sdk dependency from node/ repo. We should ideally add it back later but for now, let's just get tests running and working. Properly fixing it would require updating all dependencies to the latest: https://github.com/near/mpc-recovery/pull/451