### PR TITLE
Added key versions

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -294,7 +294,16 @@ impl MpcContract {
     }
 
     #[allow(unused_variables)]
-    pub fn sign(&mut self, payload: [u8; 32], path: String) -> Promise {
+    pub fn sign(&mut self, payload: [u8; 32], path: String, key_version: u32) -> Promise {
+        // Key versions refer new versions of the root key that we may choose to generate on cohort changes
+        // Older key versions will always work but newer key versions were never held by older signers
+        // Newer key versions may also add new security features, like only existing within a secure enclave
+        let latest_key_version: u32 = self.latest_key_version();
+        assert!(
+            key_version <= latest_key_version,
+            "This version of the signer contract doesn't support versions greater than {}",
+            latest_key_version,
+        );
         log!(
             "sign: signer={}, payload={:?} path={:?}",
             env::signer_account_id(),
@@ -373,5 +382,9 @@ impl MpcContract {
             ProtocolContractState::Resharing(state) => state.public_key.clone(),
             _ => env::panic_str("public key not available (protocol is not running or resharing)"),
         }
+    }
+
+    pub const fn latest_key_version(&self) -> u32 {
+        0
     }
 }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -294,6 +294,7 @@ impl MpcContract {
     }
 
     #[allow(unused_variables)]
+    /// `key_version` must be less than or equal to the value at `latest_key_version`
     pub fn sign(&mut self, payload: [u8; 32], path: String, key_version: u32) -> Promise {
         let latest_key_version: u32 = self.latest_key_version();
         assert!(

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -295,9 +295,6 @@ impl MpcContract {
 
     #[allow(unused_variables)]
     pub fn sign(&mut self, payload: [u8; 32], path: String, key_version: u32) -> Promise {
-        // Key versions refer new versions of the root key that we may choose to generate on cohort changes
-        // Older key versions will always work but newer key versions were never held by older signers
-        // Newer key versions may also add new security features, like only existing within a secure enclave
         let latest_key_version: u32 = self.latest_key_version();
         assert!(
             key_version <= latest_key_version,
@@ -384,6 +381,9 @@ impl MpcContract {
         }
     }
 
+    /// Key versions refer new versions of the root key that we may choose to generate on cohort changes
+    /// Older key versions will always work but newer key versions were never held by older signers
+    /// Newer key versions may also add new security features, like only existing within a secure enclave
     pub const fn latest_key_version(&self) -> u32 {
         0
     }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -384,6 +384,7 @@ impl MpcContract {
     /// Key versions refer new versions of the root key that we may choose to generate on cohort changes
     /// Older key versions will always work but newer key versions were never held by older signers
     /// Newer key versions may also add new security features, like only existing within a secure enclave
+    /// Currently only 0 is a valid key version
     pub const fn latest_key_version(&self) -> u32 {
         0
     }


### PR DESCRIPTION
Now we can change the root key if needed without needing to change the signing contracts API.

Not sure that's how you do an assert in contract, but I was going to get dragged in review anyway.