### PR TITLE
try fix CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4117,9 +4117,9 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91114c2e5549a588656ebd3647023ba65781955c81b26382158f011632e87b10"
+checksum = "2ae1eaab1d545a9be7a55b6ef09f365c2017f93a03063547591d12c0c6d27e58"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4156,9 +4156,9 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30b00f193047834bcab85e6a7a08dddba9a13efcff9fdd6fdb383b9bca6f129"
+checksum = "2991d2912218a80ec0733ac87f84fa803accea105611eea209d4419271957667"
 dependencies = [
  "blake2",
  "borsh 1.3.1",
@@ -4169,8 +4169,8 @@ dependencies = [
  "ed25519-dalek 2.1.0",
  "hex 0.4.3",
  "near-account-id 1.0.0",
- "near-config-utils 0.20.0",
- "near-stdx 0.20.0",
+ "near-config-utils 0.20.1",
+ "near-stdx 0.20.1",
  "once_cell",
  "primitive-types",
  "rand 0.7.3",
@@ -4210,11 +4210,11 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c527706c68c4e6fa8a6fa67a97ee2dbd61db8ecfd4b8e90e7be7d0814d33e9"
+checksum = "b7d998dfc1e04001608899b2498ad5a782c7d036b73769d510de21964db99286"
 dependencies = [
- "near-primitives-core 0.20.0",
+ "near-primitives-core 0.20.1",
 ]
 
 [[package]]
@@ -4350,16 +4350,16 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d680f56489eee8ddac5a6828ac97893728046a9d5cc76388f89141da4e542cc"
+checksum = "d20762631bc8253030013bbae9b5f0542691edc1aa6722f1e8141cc9b928ae5b"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap 4.4.18",
- "near-crypto 0.20.0",
- "near-fmt 0.20.0",
- "near-primitives-core 0.20.0",
+ "near-crypto 0.20.1",
+ "near-fmt 0.20.1",
+ "near-primitives-core 0.20.1",
  "once_cell",
  "opentelemetry 0.17.0",
  "opentelemetry-otlp 0.10.0",
@@ -4378,15 +4378,15 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ded008bbe48d6cc7617bfa19812179a4c15c763a9cdf61b87eb8a7bdbe10f1b"
+checksum = "e9f16a59b6c3e69b0585be951af6fe42a0ba86c0e207cb8c63badd19efd16680"
 dependencies = [
  "assert_matches",
  "borsh 1.3.1",
  "enum-map",
  "near-account-id 1.0.0",
- "near-primitives-core 0.20.0",
+ "near-primitives-core 0.20.1",
  "num-rational",
  "serde",
  "serde_repr",
@@ -4434,9 +4434,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5414b66630a38526902dc5d655581476610f6b0c64cffa49b1756fe64e519bc2"
+checksum = "0462b067732132babcc89d5577db3bfcb0a1bcfbaaed3f2db4c11cd033666314"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4448,13 +4448,13 @@ dependencies = [
  "easy-ext",
  "enum-map",
  "hex 0.4.3",
- "near-crypto 0.20.0",
- "near-fmt 0.20.0",
- "near-o11y 0.20.0",
+ "near-crypto 0.20.1",
+ "near-fmt 0.20.1",
+ "near-o11y 0.20.1",
  "near-parameters",
- "near-primitives-core 0.20.0",
- "near-rpc-error-macro 0.20.0",
- "near-stdx 0.20.0",
+ "near-primitives-core 0.20.1",
+ "near-rpc-error-macro 0.20.1",
+ "near-stdx 0.20.1",
  "near-vm-runner",
  "num-rational",
  "once_cell",
@@ -4498,9 +4498,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830f6932e0898e486b2bfb61b709a8a9d8d05c23d8398c5aeca62cb929cc2a56"
+checksum = "8443eb718606f572c438be6321a097a8ebd69f8e48d953885b4f16601af88225"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4531,9 +4531,9 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ec84c3da6dfefed08aad6920d45a09867c11a61f1c7f312d4be68ea7fc79fc"
+checksum = "80fca203c51edd9595ec14db1d13359fb9ede32314990bf296b6c5c4502f6ab7"
 dependencies = [
  "quote",
  "serde",
@@ -4554,12 +4554,12 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4393a80a2173a48e3ef284fdb63f6adb6cdde8f3bdf242aa9628b50a6f79e392"
+checksum = "897a445de2102f6732c8a185d922f5e3bf7fd0a41243ce40854df2197237f799"
 dependencies = [
  "fs2",
- "near-rpc-error-core 0.20.0",
+ "near-rpc-error-core 0.20.1",
  "serde",
  "syn 2.0.48",
 ]
@@ -4589,11 +4589,11 @@ dependencies = [
  "bs58 0.4.0",
  "near-abi 0.4.0",
  "near-account-id 1.0.0",
- "near-crypto 0.20.0",
+ "near-crypto 0.20.1",
  "near-gas",
  "near-parameters",
- "near-primitives 0.20.0",
- "near-primitives-core 0.20.0",
+ "near-primitives 0.20.1",
+ "near-primitives-core 0.20.1",
  "near-sdk-macros",
  "near-sys",
  "near-token",
@@ -4630,9 +4630,9 @@ checksum = "6540152fba5e96fe5d575b79e8cd244cf2add747bb01362426bdc069bc3a23bc"
 
 [[package]]
 name = "near-stdx"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6cc34a471c6e01f9dafa6aaa2d0553a3fe859dbb0d7fc73ca73f72731392226"
+checksum = "855fd5540e3b4ff6fedf12aba2db1ee4b371b36f465da1363a6d022b27cb43b8"
 
 [[package]]
 name = "near-sys"
@@ -4667,19 +4667,19 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f13ed25ccb25f066790290b5aca1800d87da2c4d0916217a17bc8f3ad00cdf"
+checksum = "c56c80bdb1954808f59bd36a9112377197b38d424991383bf05f52d0fe2e0da5"
 dependencies = [
  "base64 0.21.7",
  "borsh 1.3.1",
  "ed25519-dalek 2.1.0",
  "enum-map",
  "memoffset",
- "near-crypto 0.20.0",
+ "near-crypto 0.20.1",
  "near-parameters",
- "near-primitives-core 0.20.0",
- "near-stdx 0.20.0",
+ "near-primitives-core 0.20.1",
+ "near-stdx 0.20.1",
  "num-rational",
  "once_cell",
  "prefix-sum-vec",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -39,7 +39,7 @@ sha2 = "0.10.8"
 near-crypto = "0.17"
 near-fetch = "0.0.12"
 near-jsonrpc-client = "0.6"
-near-primitives = "0.17"
+near-primitives = "0.17.0"
 near-lake-framework = { git = "https://github.com/near/near-lake-framework-rs.git", branch = "daniyar/upgrade-sdk" }
 near-lake-primitives = { git = "https://github.com/near/near-lake-framework-rs.git", branch = "daniyar/upgrade-sdk" }
 

--- a/mpc-recovery/Cargo.toml
+++ b/mpc-recovery/Cargo.toml
@@ -50,7 +50,7 @@ tracing-opentelemetry = "0.21.0"
 near-fetch = "0.0.12"
 near-jsonrpc-client = "0.6"
 near-jsonrpc-primitives = "0.17"
-near-primitives = "0.17"
+near-primitives = "0.17.0"
 near-crypto = "0.17"
 tower-http = { version = "0.4.0", features = ["cors"] }
 yup-oauth2 = "8"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -41,7 +41,7 @@ near-crypto = "0.17"
 near-fetch = "0.0.12"
 near-lake-framework = { git = "https://github.com/near/near-lake-framework-rs.git", branch = "daniyar/upgrade-sdk" }
 near-lake-primitives = { git = "https://github.com/near/near-lake-framework-rs.git", branch = "daniyar/upgrade-sdk" }
-near-primitives = "0.17"
+near-primitives = "0.17.0"
 near-sdk = "5.0.0-alpha.1"
 
 mpc-contract = { path = "../contract" }


### PR DESCRIPTION
so it's not the 0.17.0 that fixed it. I'm guessing it's 0.17.0 + the changes in Cargo.lock that I forgot how I got there in my triples PR. But this fixes the broken CI for now