### PR TITLE
Allow sabmitting the same poyload

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -309,14 +309,10 @@ impl MpcContract {
             payload,
             path
         );
-        match self.pending_requests.get(&payload) {
-            None => {
-                self.pending_requests.insert(&payload, &None);
-                log!(&serde_json::to_string(&near_sdk::env::random_seed_array()).unwrap());
-                Self::ext(env::current_account_id()).sign_helper(payload, 0)
-            }
-            Some(_) => env::panic_str("Signature for this payload already requested"),
-        }
+        // TODO: prevent submitting the same paload twice which can cause conflicts
+        self.pending_requests.insert(&payload, &None);
+        log!(&serde_json::to_string(&near_sdk::env::random_seed_array()).unwrap());
+        Self::ext(env::current_account_id()).sign_helper(payload, 0)
     }
 
     #[private]

--- a/integration-tests/tests/multichain/actions/mod.rs
+++ b/integration-tests/tests/multichain/actions/mod.rs
@@ -10,14 +10,17 @@ use mpc_recovery_node::kdf;
 use mpc_recovery_node::util::ScalarExt;
 use near_crypto::InMemorySigner;
 use near_jsonrpc_client::methods::broadcast_tx_async::RpcBroadcastTxAsyncRequest;
+use near_jsonrpc_client::methods::broadcast_tx_commit::RpcBroadcastTxCommitRequest;
 use near_lake_primitives::CryptoHash;
 use near_primitives::transaction::{Action, FunctionCallAction, Transaction};
+use near_primitives::views::FinalExecutionStatus;
 use near_workspaces::Account;
 use rand::Rng;
 
+use core::sync;
 use std::time::Duration;
 
-pub async fn request_sign(
+pub async fn request_sign_async(
     ctx: &MultichainTestContext<'_>,
 ) -> anyhow::Result<([u8; 32], Account, CryptoHash)> {
     let worker = &ctx.nodes.ctx().worker;
@@ -58,6 +61,44 @@ pub async fn request_sign(
     Ok((payload, account, tx_hash))
 }
 
+pub async fn request_sign_sync(
+    ctx: &MultichainTestContext<'_>,
+) -> anyhow::Result<([u8; 32], Account, FullSignature<Secp256k1>)> {
+    let worker = &ctx.nodes.ctx().worker;
+    let account = worker.dev_create_account().await?;
+    let payload: [u8; 32] = rand::thread_rng().gen();
+    let signer = InMemorySigner {
+        account_id: account.id().clone(),
+        public_key: account.secret_key().public_key().clone().into(),
+        secret_key: account.secret_key().to_string().parse()?,
+    };
+    let receiver_id = ctx.nodes.ctx().mpc_contract.id();
+    let actions = vec![Action::FunctionCall(FunctionCallAction {
+        method_name: "sign".to_string(),
+        args: serde_json::to_vec(&serde_json::json!({
+            "payload": payload,
+            "path": "test",
+        }))?,
+        gas: 300_000_000_000_000,
+        deposit: 0,
+    })];
+    let outcome = ctx
+        .rpc_client
+        .send_tx(&signer, &receiver_id, actions)
+        .await?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    tracing::info!("outcome: {:?}", outcome);
+    match outcome.status {
+        FinalExecutionStatus::SuccessValue(signature_primitives_bytes) => {
+            let (big_r, s): (AffinePoint, Scalar) =
+                serde_json::from_slice(&signature_primitives_bytes)?;
+            let signature = cait_sith::FullSignature::<Secp256k1> { big_r, s };
+            Ok((payload, account, signature))
+        }
+        _ => anyhow::bail!("transaction failed: {:?}", outcome),
+    }
+}
+
 pub async fn assert_signature(
     account_id: &near_workspaces::AccountId,
     pk_bytes: &[u8],
@@ -74,13 +115,25 @@ pub async fn assert_signature(
     ));
 }
 
-pub async fn single_signature_production(
+pub async fn single_signature_production_async(
     ctx: &MultichainTestContext<'_>,
     state: &RunningContractState,
 ) -> anyhow::Result<()> {
-    let (payload, account, tx_hash) = request_sign(ctx).await?;
+    let (payload, account, tx_hash) = request_sign_async(ctx).await?;
     let signature = wait_for::signature_responded(ctx, tx_hash).await?;
 
+    let mut pk_bytes = vec![0x04];
+    pk_bytes.extend_from_slice(&state.public_key.as_bytes()[1..]);
+    assert_signature(account.id(), &pk_bytes, &payload, &signature).await;
+
+    Ok(())
+}
+
+pub async fn single_signature_production_sync(
+    ctx: &MultichainTestContext<'_>,
+    state: &RunningContractState,
+) -> anyhow::Result<()> {
+    let (payload, account, signature) = request_sign_sync(ctx).await?;
     let mut pk_bytes = vec![0x04];
     pk_bytes.extend_from_slice(&state.public_key.as_bytes()[1..]);
     assert_signature(account.id(), &pk_bytes, &payload, &signature).await;

--- a/integration-tests/tests/multichain/actions/mod.rs
+++ b/integration-tests/tests/multichain/actions/mod.rs
@@ -10,14 +10,12 @@ use mpc_recovery_node::kdf;
 use mpc_recovery_node::util::ScalarExt;
 use near_crypto::InMemorySigner;
 use near_jsonrpc_client::methods::broadcast_tx_async::RpcBroadcastTxAsyncRequest;
-use near_jsonrpc_client::methods::broadcast_tx_commit::RpcBroadcastTxCommitRequest;
 use near_lake_primitives::CryptoHash;
 use near_primitives::transaction::{Action, FunctionCallAction, Transaction};
 use near_primitives::views::FinalExecutionStatus;
 use near_workspaces::Account;
 use rand::Rng;
 
-use core::sync;
 use std::time::Duration;
 
 pub async fn request_sign_async(
@@ -84,10 +82,11 @@ pub async fn request_sign_sync(
     })];
     let outcome = ctx
         .rpc_client
-        .send_tx(&signer, &receiver_id, actions)
+        .send_tx(&signer, receiver_id, actions)
         .await?;
     tokio::time::sleep(Duration::from_secs(1)).await;
     tracing::info!("outcome: {:?}", outcome);
+
     match outcome.status {
         FinalExecutionStatus::SuccessValue(signature_primitives_bytes) => {
             let (big_r, s): (AffinePoint, Scalar) =

--- a/integration-tests/tests/multichain/mod.rs
+++ b/integration-tests/tests/multichain/mod.rs
@@ -54,14 +54,28 @@ async fn test_triples_and_presignatures() -> anyhow::Result<()> {
 }
 
 #[test(tokio::test)]
-async fn test_signature() -> anyhow::Result<()> {
+async fn test_signature_async() -> anyhow::Result<()> {
     with_multichain_nodes(3, |ctx| {
         Box::pin(async move {
             let state_0 = wait_for::running_mpc(&ctx, 0).await?;
             assert_eq!(state_0.participants.len(), 3);
             wait_for::has_at_least_triples(&ctx, 2).await?;
             wait_for::has_at_least_presignatures(&ctx, 2).await?;
-            actions::single_signature_production(&ctx, &state_0).await
+            actions::single_signature_production_async(&ctx, &state_0).await
+        })
+    })
+    .await
+}
+
+#[test(tokio::test)]
+async fn test_signature_sync() -> anyhow::Result<()> {
+    with_multichain_nodes(3, |ctx| {
+        Box::pin(async move {
+            let state_0 = wait_for::running_mpc(&ctx, 0).await?;
+            assert_eq!(state_0.participants.len(), 3);
+            wait_for::has_at_least_triples(&ctx, 2).await?;
+            wait_for::has_at_least_presignatures(&ctx, 2).await?;
+            actions::single_signature_production_sync(&ctx, &state_0).await
         })
     })
     .await


### PR DESCRIPTION
- Added the test for sync the `sign` call
- Allowed submitting the same payload again. `near-fetch` retries and throws "Signature for this payload already requested". I'm still not sure how and why that works in NEAR CLI.

I do not think that check is important now, but it's causing many problems for testing and development. We will need to redesign it when we have more time.