### PR TITLE
5x faster unit test compilation on nix dev env

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -13,6 +13,3 @@ rustflags = [
   "-C", "link-arg=-undefined",
   "-C", "link-arg=dynamic_lookup",
 ]
-
-[build]
-rustc-wrapper = "sccache"

--- a/.cargo/config
+++ b/.cargo/config
@@ -13,3 +13,6 @@ rustflags = [
   "-C", "link-arg=-undefined",
   "-C", "link-arg=dynamic_lookup",
 ]
+
+[build]
+rustc-wrapper = "sccache"

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
               # Development
               cargo-watch
               cargo-audit
+              sccache
             ] ++
 
             pkgs.lib.optionals pkgs.stdenv.isDarwin

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,11 @@
       in {
         devShell = pkgs.mkShell {
 
+          env = {
+            SCCACHE_GHA_ENABLED = true;
+            RUSTC_WRAPPER = "sccache";
+          };
+
           # Everything in this list is added to your path
           buildInputs =
             with pkgs;


### PR DESCRIPTION
Both on a warm cache:

Before:
cargo test test_pk_recovery  635.13s user 26.51s system 679% cpu 1:37.38 total

After:
cargo test test_pk_recovery  45.39s user 11.66s system 280% cpu 20.361 total

I should probably find out why our compile cache keeps getting invalidated, but this is a quick win. Cost is this adds in a new native dependency.