### PR TITLE
Removed spurious recompile on integration tests

### DIFF
--- a/integration-tests/src/mpc.rs
+++ b/integration-tests/src/mpc.rs
@@ -44,6 +44,7 @@ async fn build_package(
     package: &str,
     target: Option<&str>,
 ) -> anyhow::Result<ExitStatus> {
+    // Do you have direnv installed?
     let has_direnv = Command::new("which")
         .arg("direnv")
         .output()
@@ -52,8 +53,10 @@ async fn build_package(
         .status.success();
 
     let mut cmd = if has_direnv {
+        // If so use the same compiler you always use
         Command::new("direnv exec cargo")
     } else {
+        // Otherwise give up and face the pain of constant recompilation
         Command::new("cargo")
     };
     cmd.arg("build")

--- a/integration-tests/src/mpc.rs
+++ b/integration-tests/src/mpc.rs
@@ -1,4 +1,4 @@
-use std::{path::{Path, PathBuf}};
+use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use async_process::{Child, Command, ExitStatus, Stdio};
@@ -50,7 +50,8 @@ async fn build_package(
         .output()
         .await
         .expect("Failed to execute which command")
-        .status.success();
+        .status
+        .success();
 
     let mut cmd = if has_direnv {
         // If so use the same compiler you always use

--- a/integration-tests/src/mpc.rs
+++ b/integration-tests/src/mpc.rs
@@ -1,4 +1,4 @@
-use std::{path::{Path, PathBuf}, fs};
+use std::{path::{Path, PathBuf}};
 
 use anyhow::Context;
 use async_process::{Child, Command, ExitStatus, Stdio};

--- a/integration-tests/src/mpc.rs
+++ b/integration-tests/src/mpc.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::{path::{Path, PathBuf}, fs};
 
 use anyhow::Context;
 use async_process::{Child, Command, ExitStatus, Stdio};
@@ -44,7 +44,18 @@ async fn build_package(
     package: &str,
     target: Option<&str>,
 ) -> anyhow::Result<ExitStatus> {
-    let mut cmd = Command::new("cargo");
+    let has_direnv = Command::new("which")
+        .arg("direnv")
+        .output()
+        .await
+        .expect("Failed to execute which command")
+        .status.success();
+
+    let mut cmd = if has_direnv {
+        Command::new("direnv exec cargo")
+    } else {
+        Command::new("cargo")
+    };
     cmd.arg("build")
         .arg("--package")
         .arg(package)


### PR DESCRIPTION
I noticed we're using different compilers to compile our wasm and native binaries. This means they keep blowing out each others caches forcing a recompile.

This fixes that, but only for people using nix/direnv.