### PR TITLE
chore: Ignore RUSTSEC-2024-0019

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -51,4 +51,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2023-0052 --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2023-0071
+          args: --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2023-0052 --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2024-0019


### PR DESCRIPTION
Does not effect us. We are mainly using linux, and also our tokio version is under 1.30, so doesn't affect us at all. Info: https://github.com/advisories/GHSA-r8w9-5wcg-vfj7