### PR TITLE
feat: stop infinite loop of triple timeout by adding cache for failed triples

### DIFF
--- a/node/src/gcp/mod.rs
+++ b/node/src/gcp/mod.rs
@@ -229,7 +229,6 @@ impl DatastoreService {
             transaction: None,
         };
 
-        tracing::debug!(?request);
         let (_, _) = self
             .datastore
             .projects()

--- a/node/src/protocol/consensus.rs
+++ b/node/src/protocol/consensus.rs
@@ -132,7 +132,7 @@ impl ConsensusProtocol for StartedState {
                                         contract_state.threshold,
                                         epoch,
                                         ctx.triple_cfg(),
-                                        vec![],
+                                        self.triple_data,
                                         ctx.triple_storage(),
                                     );
 

--- a/node/src/protocol/message.rs
+++ b/node/src/protocol/message.rs
@@ -213,12 +213,12 @@ impl MessageHandler for RunningState {
         let participants = ctx.mesh().active_participants();
         let mut triple_manager = self.triple_manager.write().await;
 
-        // remove the triple_id that has been timed out from the triple_bins
+        // remove the triple_id that has already failed from the triple_bins
         queue
             .triple_bins
             .entry(self.epoch)
             .or_default()
-            .retain(|id, _| !triple_manager.triples_time_out.contains(&id));
+            .retain(|id, _| !triple_manager.failed_triples.contains_key(id));
 
         for (id, queue) in queue.triple_bins.entry(self.epoch).or_default() {
             if let Some(protocol) = triple_manager.get_or_generate(*id, participants)? {
@@ -312,6 +312,7 @@ impl MessageHandler for RunningState {
                 );
                 queue.extend(leftover_messages);
             }
+            triple_manager.clear_failed_triples();
         }
         Ok(())
     }

--- a/node/src/protocol/message.rs
+++ b/node/src/protocol/message.rs
@@ -212,6 +212,14 @@ impl MessageHandler for RunningState {
     ) -> Result<(), MessageHandleError> {
         let participants = ctx.mesh().active_participants();
         let mut triple_manager = self.triple_manager.write().await;
+
+        // remove the triple_id that has been timed out from the triple_bins
+        queue
+            .triple_bins
+            .entry(self.epoch)
+            .or_default()
+            .retain(|id, _| !triple_manager.triples_time_out.contains(&id));
+
         for (id, queue) in queue.triple_bins.entry(self.epoch).or_default() {
             if let Some(protocol) = triple_manager.get_or_generate(*id, participants)? {
                 while let Some(message) = queue.pop_front() {

--- a/node/src/protocol/triple.rs
+++ b/node/src/protocol/triple.rs
@@ -177,7 +177,7 @@ impl TripleManager {
             max_triples,
         } = self.triple_cfg;
         let not_enough_triples =
-            || self.my_len() < min_triples && self.potential_len() < max_triples;
+            || self.my_len() < min_triples && self.potential_len() - self.len() < max_triples;
 
         if not_enough_triples() {
             self.generate(participants)?;

--- a/node/src/protocol/triple.rs
+++ b/node/src/protocol/triple.rs
@@ -311,7 +311,7 @@ impl TripleManager {
                     Ok(action) => action,
                     Err(e) => {
                         result = Err(e);
-                        self.failed_triples.insert(*id, generator.timestamp);
+                        self.failed_triples.insert(*id, Instant::now());
                         tracing::info!("added {} to failed triples", id.clone());
                         break false;
                     }

--- a/node/src/protocol/triple.rs
+++ b/node/src/protocol/triple.rs
@@ -311,6 +311,7 @@ impl TripleManager {
                     Err(e) => {
                         result = Err(e);
                         self.triples_time_out.insert(id.clone());
+                        tracing::info!("added {} to time out triples", id.clone());
                         break false;
                     }
                 };

--- a/node/src/protocol/triple.rs
+++ b/node/src/protocol/triple.rs
@@ -176,8 +176,10 @@ impl TripleManager {
             min_triples,
             max_triples,
         } = self.triple_cfg;
-        let not_enough_triples =
-            || (self.my_len() < min_triples && self.potential_len() == self.len()) || self.potential_len() < max_triples ;
+        let not_enough_triples = || {
+            (self.my_len() < min_triples && self.potential_len() == self.len())
+                || self.potential_len() < max_triples
+        };
 
         if not_enough_triples() {
             self.generate(participants)?;

--- a/node/src/protocol/triple.rs
+++ b/node/src/protocol/triple.rs
@@ -151,7 +151,7 @@ impl TripleManager {
     /// Clears an entry from failed triples if that triple protocol was created more than 2 hrs ago
     pub fn clear_failed_triples(&mut self) {
         self.failed_triples
-            .retain(|_, timestamp| timestamp.elapsed() > crate::types::FAILED_TRIPLES_TIMEOUT)
+            .retain(|_, timestamp| timestamp.elapsed() < crate::types::FAILED_TRIPLES_TIMEOUT)
     }
 
     /// Starts a new Beaver triple generation protocol.

--- a/node/src/protocol/triple.rs
+++ b/node/src/protocol/triple.rs
@@ -177,7 +177,7 @@ impl TripleManager {
             max_triples,
         } = self.triple_cfg;
         let not_enough_triples =
-            || self.my_len() < min_triples && self.potential_len() - self.len() < max_triples;
+            || (self.my_len() < min_triples && self.potential_len() == self.len()) || self.potential_len() < max_triples ;
 
         if not_enough_triples() {
             self.generate(participants)?;

--- a/node/src/protocol/triple.rs
+++ b/node/src/protocol/triple.rs
@@ -176,10 +176,8 @@ impl TripleManager {
             min_triples,
             max_triples,
         } = self.triple_cfg;
-        let not_enough_triples = || {
-            (self.my_len() < min_triples && self.potential_len() == self.len())
-                || self.potential_len() < max_triples
-        };
+        let not_enough_triples =
+            || self.my_len() < min_triples || self.potential_len() < max_triples;
 
         if not_enough_triples() {
             self.generate(participants)?;

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -22,6 +22,9 @@ pub const PROTOCOL_PRESIG_TIMEOUT: Duration = Duration::from_secs(60);
 /// Default timeout for signature generation protocol. Times out after 1 minutes of being alive since this should be shorted lived.
 pub const PROTOCOL_SIGNATURE_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Default invalidation time for failed triples. 120 mins
+pub const FAILED_TRIPLES_TIMEOUT: Duration = Duration::from_secs(120 * 60);
+
 pub type SecretKeyShare = <Secp256k1 as CurveArithmetic>::Scalar;
 pub type PublicKey = <Secp256k1 as CurveArithmetic>::AffinePoint;
 pub type TripleProtocol =


### PR DESCRIPTION
**Purpose**
While trying out redeploying nodes at different times, I find that in the case when a large number of (>10) triple generation protocols are ongoing, the nodes could go into the infinite loop of: timing out the protocol for a triple id -> receiving message to generate the same triple from another node that has not timed out their protocol -> joining protocol to generate that same triple -> timing out.  This happens because each node would join the triple generation protocol at a different time and nodes cannot time out other nodes' protocols.
This PR adds a cache for failed triples, so that each node will not retry any failed (including timed out) triples. Then when the other nodes do not receive responses from this node about this triple protocol, they will time it out and thus close the loop for this triple generation instead of infinite looping. They could move on to generating other triples instead of resources being stuck in infinite loops of failed triples.

**What's changed in code**
1) add failed_triples: triple_id -> timestamp to TripleManager
2) when a triple generation protocol fail, add the triple_id and the timestamp we find out it failed to the failed_triples
3) when we received a message to generate a triple which has ID that is in failed_triples, we skip that message, and update the timestamp of that ID in failed_triples 
4) clear_failed_triples() will run at the end of run(), this clears all failed triples that either failed or messaged more than 2 hrs ago
