### PR TITLE
Revert "Removed spurious recompile on integration tests (#468)"

### DIFF
--- a/integration-tests/src/mpc.rs
+++ b/integration-tests/src/mpc.rs
@@ -44,22 +44,7 @@ async fn build_package(
     package: &str,
     target: Option<&str>,
 ) -> anyhow::Result<ExitStatus> {
-    // Do you have direnv installed?
-    let has_direnv = Command::new("which")
-        .arg("direnv")
-        .output()
-        .await
-        .expect("Failed to execute which command")
-        .status
-        .success();
-
-    let mut cmd = if has_direnv {
-        // If so use the same compiler you always use
-        Command::new("direnv exec cargo")
-    } else {
-        // Otherwise give up and face the pain of constant recompilation
-        Command::new("cargo")
-    };
+    let mut cmd = Command::new("cargo");
     cmd.arg("build")
         .arg("--package")
         .arg(package)


### PR DESCRIPTION
This reverts commit 994a17e19f1333f20634ad5f0a8a5e6622d0e9df.

This sped up compilation on nix, but rather embarrassingly broke it at the same time. The shame.