### PR TITLE
Make the key version mandatory

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -295,8 +295,7 @@ impl MpcContract {
 
     #[allow(unused_variables)]
     /// `key_version` must be less than or equal to the value at `latest_key_version`
-    pub fn sign(&mut self, payload: [u8; 32], path: String, key_version: Option<u32>) -> Promise {
-        let key_version = key_version.unwrap_or(0);
+    pub fn sign(&mut self, payload: [u8; 32], path: String, key_version: u32) -> Promise {
         let latest_key_version: u32 = self.latest_key_version();
         assert!(
             key_version <= latest_key_version,

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -303,7 +303,7 @@ impl MpcContract {
             latest_key_version,
         );
         log!(
-            "sign: signer={}, payload={:?} path={:?}",
+            "sign: signer={}, payload={:?}, path={:?}, key_version={}",
             env::signer_account_id(),
             payload,
             path,

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -306,7 +306,8 @@ impl MpcContract {
             "sign: signer={}, payload={:?} path={:?}",
             env::signer_account_id(),
             payload,
-            path
+            path,
+            key_version
         );
         match self.pending_requests.get(&payload) {
             None => {

--- a/integration-tests/tests/multichain/actions/mod.rs
+++ b/integration-tests/tests/multichain/actions/mod.rs
@@ -62,6 +62,7 @@ pub async fn request_sign(
                     args: serde_json::to_vec(&serde_json::json!({
                         "payload": payload_hashed,
                         "path": "test",
+                        "key_version": 0,
                     }))?,
                     gas: 300_000_000_000_000,
                     deposit: 0,

--- a/node/src/indexer.rs
+++ b/node/src/indexer.rs
@@ -67,6 +67,7 @@ impl Options {
 struct SignPayload {
     payload: [u8; 32],
     path: String,
+    key_version: u32,
 }
 
 #[derive(LakeContext)]
@@ -111,6 +112,7 @@ async fn handle_block(
                             receipt_id = %receipt_id,
                             caller_id = receipt.predecessor_id().to_string(),
                             payload = hex::encode(sign_payload.payload),
+                            key_version = sign_payload.key_version,
                             entropy = hex::encode(entropy),
                             "indexed new `sign` function call"
                         );


### PR DESCRIPTION
We'll update key versions when we increase the security of our system, or periodically lower the amount of assets accessible to former validator cohorts. New key versions mean new keys.

Previously this field was optional, but if we leave it optional we have to make a decision to either interpret None as 0, the least secure key version, or continually update it to the latest one, changing peoples keys from under them.

Since there isn't a good answer I feel it's better to make them mandatory, so people at least have to think about them a bit.