### PR TITLE
fix: issues with already taken triple and presig

### DIFF
--- a/node/src/protocol/message.rs
+++ b/node/src/protocol/message.rs
@@ -328,8 +328,10 @@ impl MessageHandler for RunningState {
                 );
                 queue.extend(leftover_messages);
             }
-            triple_manager.clear_failed_triples();
         }
+        triple_manager.clear_failed_triples();
+        triple_manager.clear_taken();
+        presignature_manager.clear_taken();
         Ok(())
     }
 }

--- a/node/src/protocol/presignature.rs
+++ b/node/src/protocol/presignature.rs
@@ -155,7 +155,7 @@ impl PresignatureManager {
 
     pub fn clear_taken(&mut self) {
         self.taken
-            .retain(|_, instant| instant.elapsed() < crate::types::PROTOCOL_PRESIG_TIMEOUT);
+            .retain(|_, instant| instant.elapsed() < crate::types::TAKEN_TIMEOUT);
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/node/src/protocol/presignature.rs
+++ b/node/src/protocol/presignature.rs
@@ -99,6 +99,9 @@ pub struct PresignatureManager {
     mine: VecDeque<PresignatureId>,
     /// The set of presignatures that were introduced to the system by the current node.
     introduced: HashSet<PresignatureId>,
+    /// The set of presignatures that were already taken. This will be maintained for at most
+    /// presignature timeout period just so messages are cycled through the system.
+    taken: HashMap<PresignatureId, Instant>,
 
     me: Participant,
     threshold: usize,
@@ -120,6 +123,7 @@ impl PresignatureManager {
             generators: HashMap::new(),
             mine: VecDeque::new(),
             introduced: HashSet::new(),
+            taken: HashMap::new(),
             me,
             threshold,
             epoch,
@@ -147,6 +151,11 @@ impl PresignatureManager {
     /// Returns if there are unspent presignatures available in the manager.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    pub fn clear_taken(&mut self) {
+        self.taken
+            .retain(|_, instant| instant.elapsed() < crate::types::PROTOCOL_PRESIG_TIMEOUT);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -288,7 +297,7 @@ impl PresignatureManager {
         public_key: &PublicKey,
         private_share: &SecretKeyShare,
     ) -> Result<&mut PresignatureProtocol, GenerationError> {
-        if self.presignatures.contains_key(&id) {
+        if self.presignatures.contains_key(&id) || self.taken.contains_key(&id) {
             Err(GenerationError::AlreadyGenerated)
         } else {
             match self.generators.entry(id) {
@@ -331,14 +340,18 @@ impl PresignatureManager {
     pub fn take_mine(&mut self) -> Option<Presignature> {
         tracing::info!(mine = ?self.mine, "my presignatures");
         let my_presignature_id = self.mine.pop_front()?;
+        self.taken.insert(my_presignature_id, Instant::now());
         Some(self.presignatures.remove(&my_presignature_id).unwrap())
     }
 
     pub fn take(&mut self, id: PresignatureId) -> Option<Presignature> {
+        self.taken.insert(id, Instant::now());
         self.presignatures.remove(&id)
     }
 
     pub fn insert_mine(&mut self, presig: Presignature) {
+        // Remove from taken list if it was there
+        self.taken.remove(&presig.id);
         self.mine.push_back(presig.id);
         self.presignatures.insert(presig.id, presig);
     }

--- a/node/src/protocol/triple.rs
+++ b/node/src/protocol/triple.rs
@@ -184,7 +184,7 @@ impl TripleManager {
 
     pub fn clear_taken(&mut self) {
         self.taken
-            .retain(|_, timestamp| timestamp.elapsed() < crate::types::PROTOCOL_TRIPLE_TIMEOUT)
+            .retain(|_, timestamp| timestamp.elapsed() < crate::types::TAKEN_TIMEOUT)
     }
 
     /// Starts a new Beaver triple generation protocol.

--- a/node/src/protocol/triple.rs
+++ b/node/src/protocol/triple.rs
@@ -56,7 +56,11 @@ impl TripleGenerator {
     pub fn poke(&mut self) -> Result<Action<TripleGenerationOutput<Secp256k1>>, ProtocolError> {
         let timestamp = self.timestamp.get_or_insert_with(Instant::now);
         if timestamp.elapsed() > crate::types::PROTOCOL_TRIPLE_TIMEOUT {
-            tracing::info!(id = self.id, "triple protocol timed out");
+            tracing::info!(
+                id = self.id,
+                elapsed = ?timestamp.elapsed(),
+                "triple protocol timed out"
+            );
             return Err(ProtocolError::Other(
                 anyhow::anyhow!("triple protocol timed out").into(),
             ));
@@ -102,6 +106,10 @@ pub struct TripleManager {
     /// List of triple ids generation of which was initiated by the current node.
     pub mine: VecDeque<TripleId>,
 
+    /// The set of triple ids that were already taken. This will be maintained for at most
+    /// triple timeout period just so messages are cycled through the system.
+    pub taken: HashMap<TripleId, Instant>,
+
     pub me: Participant,
     pub threshold: usize,
     pub epoch: u64,
@@ -136,6 +144,7 @@ impl TripleManager {
             queued: VecDeque::new(),
             ongoing: HashSet::new(),
             introduced: HashSet::new(),
+            taken: HashMap::new(),
             mine,
             me,
             threshold,
@@ -173,6 +182,11 @@ impl TripleManager {
             .retain(|_, timestamp| timestamp.elapsed() < crate::types::FAILED_TRIPLES_TIMEOUT)
     }
 
+    pub fn clear_taken(&mut self) {
+        self.taken
+            .retain(|_, timestamp| timestamp.elapsed() < crate::types::PROTOCOL_TRIPLE_TIMEOUT)
+    }
+
     /// Starts a new Beaver triple generation protocol.
     pub fn generate(&mut self, participants: &Participants) -> Result<(), InitializationError> {
         let id = rand::random();
@@ -208,9 +222,9 @@ impl TripleManager {
                 false
             } else {
                 // We will always try to generate a new triple if we have less than the minimum
-                self.my_len() <= min_triples
-                    && self.introduced.len() <= max_concurrent_introduction
-                    && self.generators.len() <= max_concurrent_generation
+                self.my_len() < min_triples
+                    && self.introduced.len() < max_concurrent_introduction
+                    && self.generators.len() < max_concurrent_generation
             }
         };
 
@@ -239,6 +253,9 @@ impl TripleManager {
             let triple2 = self.triples.get(&id1).unwrap().clone();
             self.delete_triple_from_storage(&triple1, mine).await?;
             self.delete_triple_from_storage(&triple2, mine).await?;
+            self.taken.insert(id0, Instant::now());
+            self.taken.insert(id1, Instant::now());
+
             // only remove the triples locally when the datastore removal was successful
             Ok((
                 self.triples.remove(&id0).unwrap(),
@@ -305,6 +322,7 @@ impl TripleManager {
     pub async fn insert_mine(&mut self, triple: Triple) {
         self.mine.push_back(triple.id);
         self.triples.insert(triple.id, triple.clone());
+        self.taken.remove(&triple.id);
         self.insert_triples_to_storage(vec![triple]).await;
     }
 
@@ -318,7 +336,7 @@ impl TripleManager {
         id: TripleId,
         participants: &Participants,
     ) -> Result<Option<&mut TripleProtocol>, CryptographicError> {
-        if self.triples.contains_key(&id) {
+        if self.triples.contains_key(&id) || self.taken.contains_key(&id) {
             Ok(None)
         } else {
             let potential_len = self.potential_len();
@@ -331,7 +349,7 @@ impl TripleManager {
                     }
 
                     tracing::debug!(id, "joining protocol to generate a new triple");
-                    let participants: Vec<_> = participants.keys().cloned().collect();
+                    let participants = participants.keys_vec();
                     let protocol = Box::new(cait_sith::triples::generate_triple::<Secp256k1>(
                         &participants,
                         self.me,

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -25,6 +25,9 @@ pub const PROTOCOL_SIGNATURE_TIMEOUT: Duration = Duration::from_secs(60);
 /// Default invalidation time for failed triples. 120 mins
 pub const FAILED_TRIPLES_TIMEOUT: Duration = Duration::from_secs(120 * 60);
 
+/// Default invalidation time for taken triples and presignatures. 120 mins
+pub const TAKEN_TIMEOUT: Duration = Duration::from_secs(120 * 60);
+
 pub type SecretKeyShare = <Secp256k1 as CurveArithmetic>::Scalar;
 pub type PublicKey = <Secp256k1 as CurveArithmetic>::AffinePoint;
 pub type TripleProtocol =


### PR DESCRIPTION
When the latency is too high, a node might be trying to process a message for a triple or presig that was already recently utilized and initiates a new protocol generation. This circumvents that by keeping tally of already taken up 