### PR TITLE
fix: add multichain_sign_requests_count_mine to correct sign success rate

### DIFF
--- a/node/src/metrics.rs
+++ b/node/src/metrics.rs
@@ -23,6 +23,15 @@ pub(crate) static NUM_SIGN_REQUESTS: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub(crate) static NUM_SIGN_REQUESTS_MINE: Lazy<IntGaugeVec> = Lazy::new(|| {
+    try_create_int_gauge_vec(
+        "multichain_sign_requests_count_mine",
+        "number of multichain sign requests, marked by sign requests indexed",
+        &["node_account_id"],
+    )
+    .unwrap()
+});
+
 pub(crate) static NUM_SIGN_SUCCESS: Lazy<IntGaugeVec> = Lazy::new(|| {
     try_create_int_gauge_vec(
         "multichain_sign_requests_success",

--- a/node/src/protocol/cryptography.rs
+++ b/node/src/protocol/cryptography.rs
@@ -343,11 +343,9 @@ impl CryptographicProtocol for RunningState {
 
         let mut messages = self.messages.write().await;
         let mut triple_manager = self.triple_manager.write().await;
-        let triple_storage_read_lock = triple_manager.triple_storage.read().await;
-        let my_account_id = triple_storage_read_lock.account_id();
-        drop(triple_storage_read_lock);
+        let my_account_id = triple_manager.my_account_id.clone();
         crate::metrics::MESSAGE_QUEUE_SIZE
-            .with_label_values(&[&my_account_id.to_string()])
+            .with_label_values(&[&my_account_id.as_ref()])
             .set(messages.len() as i64);
         triple_manager.stockpile(active)?;
         for (p, msg) in triple_manager.poke().await? {
@@ -356,16 +354,16 @@ impl CryptographicProtocol for RunningState {
         }
 
         crate::metrics::NUM_TRIPLES_MINE
-            .with_label_values(&[&my_account_id.to_string()])
+            .with_label_values(&[&my_account_id.as_ref()])
             .set(triple_manager.mine.len() as i64);
         crate::metrics::NUM_TRIPLES_TOTAL
-            .with_label_values(&[&my_account_id.to_string()])
+            .with_label_values(&[&my_account_id.as_ref()])
             .set(triple_manager.triples.len() as i64);
         crate::metrics::NUM_TRIPLE_GENERATORS_INTRODUCED
-            .with_label_values(&[&my_account_id.to_string()])
+            .with_label_values(&[&my_account_id.as_ref()])
             .set(triple_manager.introduced.len() as i64);
         crate::metrics::NUM_TRIPLE_GENERATORS_TOTAL
-            .with_label_values(&[&my_account_id.to_string()])
+            .with_label_values(&[&my_account_id.as_ref()])
             .set(triple_manager.ongoing.len() as i64);
 
         let mut presignature_manager = self.presignature_manager.write().await;
@@ -384,25 +382,25 @@ impl CryptographicProtocol for RunningState {
         }
 
         crate::metrics::NUM_PRESIGNATURES_MINE
-            .with_label_values(&[&my_account_id.to_string()])
+            .with_label_values(&[&my_account_id.as_ref()])
             .set(presignature_manager.my_len() as i64);
         crate::metrics::NUM_PRESIGNATURES_TOTAL
-            .with_label_values(&[&my_account_id.to_string()])
+            .with_label_values(&[&my_account_id.as_ref()])
             .set(presignature_manager.len() as i64);
         crate::metrics::NUM_PRESIGNATURE_GENERATORS_TOTAL
-            .with_label_values(&[&my_account_id.to_string()])
+            .with_label_values(&[&my_account_id.as_ref()])
             .set(presignature_manager.potential_len() as i64 - presignature_manager.len() as i64);
 
         let mut sign_queue = self.sign_queue.write().await;
         crate::metrics::SIGN_QUEUE_SIZE
-            .with_label_values(&[&my_account_id.to_string()])
+            .with_label_values(&[&my_account_id.as_ref()])
             .set(sign_queue.len() as i64);
 
         let mut signature_manager = self.signature_manager.write().await;
-        sign_queue.organize(self.threshold, active, ctx.me().await);
+        sign_queue.organize(self.threshold, active, ctx.me().await, &my_account_id);
         let my_requests = sign_queue.my_requests(ctx.me().await);
         crate::metrics::SIGN_QUEUE_MINE_SIZE
-            .with_label_values(&[&my_account_id.to_string()])
+            .with_label_values(&[&my_account_id.as_ref()])
             .set(my_requests.len() as i64);
         let mut failed_presigs = Vec::new();
         while presignature_manager.my_len() > 0 {
@@ -464,13 +462,12 @@ impl CryptographicProtocol for RunningState {
             let info = self.participants.get(&p).unwrap();
             messages.push(info.clone(), MpcMessage::Signature(msg));
         }
-        let my_account_id = &self.fetch_participant(&ctx.me().await)?.account_id;
         signature_manager
             .publish(
                 ctx.rpc_client(),
                 ctx.signer(),
                 ctx.mpc_contract_id(),
-                my_account_id,
+                &my_account_id,
             )
             .await?;
         drop(signature_manager);

--- a/node/src/protocol/signature.rs
+++ b/node/src/protocol/signature.rs
@@ -60,7 +60,13 @@ impl SignQueue {
         self.unorganized_requests.push(request);
     }
 
-    pub fn organize(&mut self, threshold: usize, active: &Participants, me: Participant, my_account_id: &AccountId) {
+    pub fn organize(
+        &mut self,
+        threshold: usize,
+        active: &Participants,
+        me: Participant,
+        my_account_id: &AccountId,
+    ) {
         for request in self.unorganized_requests.drain(..) {
             let mut rng = StdRng::from_seed(request.entropy);
             let subset = active.keys().choose_multiple(&mut rng, threshold);

--- a/node/src/protocol/signature.rs
+++ b/node/src/protocol/signature.rs
@@ -60,7 +60,7 @@ impl SignQueue {
         self.unorganized_requests.push(request);
     }
 
-    pub fn organize(&mut self, threshold: usize, active: &Participants, me: Participant) {
+    pub fn organize(&mut self, threshold: usize, active: &Participants, me: Participant, my_account_id: &AccountId) {
         for request in self.unorganized_requests.drain(..) {
             let mut rng = StdRng::from_seed(request.entropy);
             let subset = active.keys().choose_multiple(&mut rng, threshold);
@@ -75,6 +75,9 @@ impl SignQueue {
                 );
                 let proposer_requests = self.requests.entry(proposer).or_default();
                 proposer_requests.insert(request.receipt_id, request);
+                crate::metrics::NUM_SIGN_REQUESTS_MINE
+                    .with_label_values(&[my_account_id.as_ref()])
+                    .inc();
             } else {
                 tracing::info!(
                     receipt_id = %request.receipt_id,


### PR DESCRIPTION
Current code multichain_sign_requests_count = #total sign requests handled by all nodes, yet multichain_sign_requests_success = # success where me being proposer. Because me cannot know if other signature requests are successful on other nodes.
Currently, success rate = sum(success on node) /  avg(multichain_sign_requests_count)
However since nodes can be deployed at different times, this success rate may not be correct.
Thus I add  multichain_sign_requests_count_mine = number of sign requests with me being proposer
then success rate  = success on node/ multichain_sign_requests_count_mine  will be correct for each of the node
