### PR TITLE
feat: /msg endpoint now takes vectorized encrypted messages

### DIFF
--- a/node/src/protocol/message.rs
+++ b/node/src/protocol/message.rs
@@ -77,6 +77,18 @@ pub enum MpcMessage {
     Signature(SignatureMessage),
 }
 
+impl MpcMessage {
+    pub const fn typename(&self) -> &'static str {
+        match self {
+            MpcMessage::Generating(_) => "Generating",
+            MpcMessage::Resharing(_) => "Resharing",
+            MpcMessage::Triple(_) => "Triple",
+            MpcMessage::Presignature(_) => "Presignature",
+            MpcMessage::Signature(_) => "Signature",
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct MpcMessageQueue {
     generating: VecDeque<GeneratingMessage>,

--- a/node/src/protocol/message.rs
+++ b/node/src/protocol/message.rs
@@ -376,12 +376,12 @@ where
     T: Serialize,
 {
     pub fn encrypt(
-        msg: T,
+        msg: &T,
         from: Participant,
         sign_sk: &near_crypto::SecretKey,
         cipher_pk: &hpke::PublicKey,
     ) -> Result<Ciphered, CryptographicError> {
-        let msg = serde_json::to_vec(&msg)?;
+        let msg = serde_json::to_vec(msg)?;
         let sig = sign_sk.sign(&msg);
         let msg = SignedMessage { msg, sig, from };
         let msg = serde_json::to_vec(&msg)?;

--- a/node/src/web/mod.rs
+++ b/node/src/web/mod.rs
@@ -45,7 +45,6 @@ pub async fn run(
             }),
         )
         .route("/msg", post(msg))
-        .route("/msg_multi", post(msg_multi))
         .route("/state", get(state))
         .route("/metrics", get(metrics))
         .layer(Extension(Arc::new(axum_state)));
@@ -68,27 +67,6 @@ pub struct MsgRequest {
 
 #[tracing::instrument(level = "debug", skip_all)]
 async fn msg(
-    Extension(state): Extension<Arc<AxumState>>,
-    WithRejection(Json(encrypted), _): WithRejection<Json<Ciphered>, Error>,
-) -> Result<()> {
-    let message =
-        match SignedMessage::decrypt(&state.cipher_sk, &state.protocol_state, encrypted).await {
-            Ok(msg) => msg,
-            Err(err) => {
-                tracing::error!(?err, "failed to decrypt or verify an encrypted message");
-                return Err(err.into());
-            }
-        };
-
-    if let Err(err) = state.sender.send(message).await {
-        tracing::error!(?err, "failed to forward an encrypted protocol message");
-        return Err(err.into());
-    }
-    Ok(())
-}
-
-#[tracing::instrument(level = "debug", skip_all)]
-async fn msg_multi(
     Extension(state): Extension<Arc<AxumState>>,
     WithRejection(Json(encrypted), _): WithRejection<Json<Vec<Ciphered>>, Error>,
 ) -> Result<()> {

--- a/node/src/web/mod.rs
+++ b/node/src/web/mod.rs
@@ -45,6 +45,7 @@ pub async fn run(
             }),
         )
         .route("/msg", post(msg))
+        .route("/msg_multi", post(msg_multi))
         .route("/state", get(state))
         .route("/metrics", get(metrics))
         .layer(Extension(Arc::new(axum_state)));
@@ -86,7 +87,35 @@ async fn msg(
     Ok(())
 }
 
-#[derive(Serialize, Deserialize)]
+#[tracing::instrument(level = "debug", skip_all)]
+async fn msg_multi(
+    Extension(state): Extension<Arc<AxumState>>,
+    WithRejection(Json(encrypted), _): WithRejection<Json<Vec<Ciphered>>, Error>,
+) -> Result<()> {
+    for encrypted in encrypted.into_iter() {
+        let message = match SignedMessage::decrypt(
+            &state.cipher_sk,
+            &state.protocol_state,
+            encrypted,
+        )
+        .await
+        {
+            Ok(msg) => msg,
+            Err(err) => {
+                tracing::error!(?err, "failed to decrypt or verify an encrypted message");
+                return Err(err.into());
+            }
+        };
+
+        if let Err(err) = state.sender.send(message).await {
+            tracing::error!(?err, "failed to forward an encrypted protocol message");
+            return Err(err.into());
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type")]
 #[serde(rename_all = "snake_case")]
 pub enum StateView {


### PR DESCRIPTION
This optimizes the number of messages outflowing from a node, such that the network doesn't get used as much. This bundles up multiple messages into at most 256kb payloads. Reduces the latency quite a bit and increases the success rate of triples generated in time