### PR TITLE
Node and contract version metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-contract"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "borsh 1.3.1",

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpc-contract"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -401,6 +401,10 @@ impl MpcContract {
         }
     }
 
+    pub fn version(&self) -> String {
+        env!("CARGO_PKG_VERSION").to_string()
+    }
+
     /// Key versions refer new versions of the root key that we may choose to generate on cohort changes
     /// Older key versions will always work but newer key versions were never held by older signers
     /// Newer key versions may also add new security features, like only existing within a secure enclave

--- a/node/src/metrics.rs
+++ b/node/src/metrics.rs
@@ -170,10 +170,10 @@ pub(crate) static MESSAGE_QUEUE_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub(crate) static MPC_CONTRACT_VERSION: Lazy<IntGaugeVec> = Lazy::new(|| {
+pub(crate) static NODE_VERSION: Lazy<IntGaugeVec> = Lazy::new(|| {
     try_create_int_gauge_vec(
-        "multichain_contract_version",
-        "contract version, the contract is of form v[x].multichain-mpc.testnet",
+        "node_version",
+        "node semantic version",
         &["node_account_id"],
     )
     .unwrap()

--- a/node/src/metrics.rs
+++ b/node/src/metrics.rs
@@ -172,7 +172,7 @@ pub(crate) static MESSAGE_QUEUE_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
 
 pub(crate) static NODE_VERSION: Lazy<IntGaugeVec> = Lazy::new(|| {
     try_create_int_gauge_vec(
-        "node_version",
+        "multichain_node_version",
         "node semantic version",
         &["node_account_id"],
     )

--- a/node/src/protocol/mod.rs
+++ b/node/src/protocol/mod.rs
@@ -219,12 +219,9 @@ impl MpcSignProtocol {
         crate::metrics::NODE_RUNNING
             .with_label_values(&[&my_account_id])
             .set(1);
-        let mpc_contract_version = get_contract_version(&self.ctx.mpc_contract_id);
-        if let Ok(version) = mpc_contract_version {
-            crate::metrics::MPC_CONTRACT_VERSION
-                .with_label_values(&[&my_account_id])
-                .set(version);
-        }
+        crate::metrics::NODE_VERSION
+            .with_label_values(&[&my_account_id])
+            .set(node_version());
         let mut queue = MpcMessageQueue::default();
         let mut last_state_update = Instant::now();
         let mut last_pinged = Instant::now();
@@ -359,9 +356,9 @@ async fn get_my_participant(protocol: &MpcSignProtocol) -> Participant {
     participant_info.id.into()
 }
 
-fn get_contract_version(mpc_contract_account: &AccountId) -> Result<i64, std::num::ParseIntError> {
-    let mpc_contract_id = mpc_contract_account.as_str();
-    let parts: Vec<&str> = mpc_contract_id.split('.').collect();
-    let version_str = parts[0].trim_start_matches('v');
-    version_str.parse::<i64>()
+fn node_version() -> i64 {
+    env!("CARGO_PKG_VERSION")
+        .split('.')
+        .map(|s| s.parse::<i64>().unwrap())
+        .fold(0, |acc, x| acc * 1000 + x)
 }


### PR DESCRIPTION
The contract function is tested manually. For the node version, we will need to deploy and update Grafana config.
@ppca let's make sure we are [updating](https://semver.org/) the version before each deploy of contract and node.