### PR TITLE
contract: make multichain contract versioned

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -82,9 +82,9 @@ impl MpcContract {
         self.request_counter -= 1;
     }
 
-    fn check_and_insert_request(&mut self, payload: [u8; 32], big_r: String, s: String) {
-        if self.pending_requests.contains_key(&payload) {
-            self.pending_requests.insert(&payload, &Some((big_r, s)));
+    fn add_signature(&mut self, payload: &[u8; 32], signature: (String, String)) {
+        if self.pending_requests.contains_key(payload) {
+            self.pending_requests.insert(payload, &Some(signature));
         }
     }
 
@@ -426,10 +426,10 @@ impl VersionedMpcContract {
         }
     }
 
-    fn check_and_insert_request(&mut self, payload: [u8; 32], big_r: String, s: String) {
+    fn add_signature(&mut self, payload: &[u8; 32], signature: (String, String)) {
         match self {
             Self::V0(mpc_contract) => {
-                mpc_contract.check_and_insert_request(payload, big_r, s);
+                mpc_contract.add_signature(payload, signature);
             }
         }
     }
@@ -534,7 +534,7 @@ impl VersionedMpcContract {
                     big_r,
                     s
                 );
-                self.check_and_insert_request(payload, big_r, s);
+                self.add_signature(&payload, (big_r, s));
             } else {
                 env::panic_str("only participants can respond");
             }

--- a/contract/tests/tests.rs
+++ b/contract/tests/tests.rs
@@ -1,4 +1,5 @@
-use mpc_contract::primitives::CandidateInfo;
+use mpc_contract::{primitives::CandidateInfo, MpcContract, VersionedMpcContract};
+use near_sdk::env;
 use near_workspaces::AccountId;
 use std::collections::HashMap;
 
@@ -34,6 +35,22 @@ async fn test_contract_can_not_be_reinitialized() -> anyhow::Result<()> {
         .await?;
 
     assert!(result2.is_failure());
+
+    Ok(())
+}
+
+#[test]
+fn test_old_state_can_be_migrated_to_v0() -> anyhow::Result<()> {
+    let old_contract = MpcContract::test_init();
+    env::state_write(&old_contract);
+
+    let v0_contract = VersionedMpcContract::migrate_state_old_to_v0();
+    let expected_contract = VersionedMpcContract::V0(old_contract);
+
+    assert_eq!(
+        format!("{v0_contract:#?}"),
+        format!("{expected_contract:#?}")
+    );
 
     Ok(())
 }

--- a/contract/tests/tests.rs
+++ b/contract/tests/tests.rs
@@ -1,7 +1,7 @@
 use mpc_contract::{primitives::CandidateInfo, MpcContract, VersionedMpcContract};
 use near_sdk::env;
 use near_workspaces::AccountId;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 const CONTRACT_FILE_PATH: &str =
     "./../target/seperate_wasm/wasm32-unknown-unknown/release/mpc_contract.wasm";
@@ -41,7 +41,7 @@ async fn test_contract_can_not_be_reinitialized() -> anyhow::Result<()> {
 
 #[test]
 fn test_old_state_can_be_migrated_to_v0() -> anyhow::Result<()> {
-    let old_contract = MpcContract::test_init();
+    let old_contract = MpcContract::init(3, BTreeMap::new());
     env::state_write(&old_contract);
 
     let v0_contract = VersionedMpcContract::migrate_state_old_to_v0();


### PR DESCRIPTION
This will be our contract
```
pub enum VersionedMpcContract {
    V0(MpcContract),
}
```
I put majority of the fn logics in VersionedMpcContract implementation, and added functions that read data from contract, e.g.
```
fn mutable_state(&mut self) -> &mut ProtocolContractState {
        match self {
            Self::V0(ref mut mpc_contract) => &mut mpc_contract.protocol_state,
        }
    }

fn get_signature_per_payload(&self, payload: [u8; 32]) -> Option<Option<(String, String)>> {
        match self {
            Self::V0(mpc_contract) => mpc_contract.pending_requests.get(&payload),
        }
    }

    fn remove_request(&mut self, payload: &[u8; 32]) {
        match self {
            Self::V0(mpc_contract) => {
                mpc_contract.remove_request(payload);
            }
        }
    }

    fn add_request(&mut self, payload: &[u8; 32], signature: &Option<(String, String)>) {
        match self {
            Self::V0(mpc_contract) => {
                mpc_contract.add_request(payload, signature);
            }
        }
    }

    fn check_and_insert_request(&mut self, payload: [u8; 32], big_r: String, s: String) {
        match self {
            Self::V0(mpc_contract) => {
                mpc_contract.check_and_insert_request(payload, big_r, s);
            }
        }
    }
```
So each version could have different format of storing data and we could add code to above fn to read data from each version. 