### PR TITLE
feat: separate sign key for signing protocol messages

### DIFF
--- a/infra/modules/multichain/main.tf
+++ b/infra/modules/multichain/main.tf
@@ -80,6 +80,15 @@ resource "google_cloud_run_v2_service" "node" {
         }
       }
       env {
+        name = "MPC_RECOVERY_SIGN_SK"
+        value_source {
+          secret_key_ref {
+            secret  = var.sign_sk_secret_id
+            version = "latest"
+          }
+        }
+      }
+      env {
         name = "AWS_ACCESS_KEY_ID"
         value_source {
           secret_key_ref {

--- a/infra/modules/multichain/variables.tf
+++ b/infra/modules/multichain/variables.tf
@@ -68,6 +68,10 @@ variable "cipher_sk_secret_id" {
   type = string
 }
 
+variable "sign_sk_secret_id" {
+  type = string
+}
+
 variable "aws_access_key_secret_id" {
   type = string
 }

--- a/infra/multichain-dev/main.tf
+++ b/infra/multichain-dev/main.tf
@@ -70,6 +70,14 @@ resource "google_secret_manager_secret_iam_member" "cipher_sk_secret_access" {
   member    = "serviceAccount:${google_service_account.service_account.email}"
 }
 
+resource "google_secret_manager_secret_iam_member" "sign_sk_secret_access" {
+  count = length(var.node_configs)
+
+  secret_id = var.node_configs[count.index].sign_sk_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.service_account.email}"
+}
+
 resource "google_secret_manager_secret_iam_member" "aws_access_key_secret_access" {
   secret_id = var.aws_access_key_secret_id
   role      = "roles/secretmanager.secretAccessor"
@@ -99,10 +107,10 @@ resource "google_secret_manager_secret_iam_member" "sk_share_secret_manager" {
 }
 
 resource "google_project_iam_member" "datastore_iam_member" {
-  count = length(var.node_configs)
-  project   = var.project
-  role      = "roles/datastore.user"
-  member    = "serviceAccount:${google_service_account.service_account.email}"
+  count   = length(var.node_configs)
+  project = var.project
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.service_account.email}"
 }
 
 module "node" {
@@ -126,6 +134,7 @@ module "node" {
 
   account_sk_secret_id     = var.node_configs[count.index].account_sk_secret_id
   cipher_sk_secret_id      = var.node_configs[count.index].cipher_sk_secret_id
+  sign_sk_secret_id        = var.node_configs[count.index].sign_sk_secret_id
   aws_access_key_secret_id = var.aws_access_key_secret_id
   aws_secret_key_secret_id = var.aws_secret_key_secret_id
   sk_share_secret_id       = var.node_configs[count.index].sk_share_secret_id
@@ -133,6 +142,7 @@ module "node" {
   depends_on = [
     google_secret_manager_secret_iam_member.account_sk_secret_access,
     google_secret_manager_secret_iam_member.cipher_sk_secret_access,
+    google_secret_manager_secret_iam_member.sign_sk_secret_access,
     google_secret_manager_secret_iam_member.aws_access_key_secret_access,
     google_secret_manager_secret_iam_member.aws_secret_key_secret_access,
     google_secret_manager_secret_iam_member.sk_share_secret_access,

--- a/infra/multichain-dev/terraform-dev.tfvars
+++ b/infra/multichain-dev/terraform-dev.tfvars
@@ -19,6 +19,7 @@ node_configs = [
     address              = "https://multichain-dev-0-7tk2cmmtcq-ue.a.run.app"
     account_sk_secret_id = "multichain-account-sk-dev-0"
     cipher_sk_secret_id  = "multichain-cipher-sk-dev-0"
+    sign_sk_secret_id    = "multichain-sign-sk-dev-0"
     sk_share_secret_id   = "multichain-sk-share-dev-0"
   },
   {
@@ -27,6 +28,7 @@ node_configs = [
     address              = "https://multichain-dev-1-7tk2cmmtcq-ue.a.run.app"
     account_sk_secret_id = "multichain-account-sk-dev-1"
     cipher_sk_secret_id  = "multichain-cipher-sk-dev-1"
+    sign_sk_secret_id    = "multichain-sign-sk-dev-1"
     sk_share_secret_id   = "multichain-sk-share-dev-1"
   },
   {
@@ -35,6 +37,7 @@ node_configs = [
     address              = "https://multichain-dev-2-7tk2cmmtcq-ue.a.run.app"
     account_sk_secret_id = "multichain-account-sk-dev-2"
     cipher_sk_secret_id  = "multichain-cipher-sk-dev-2"
+    sign_sk_secret_id    = "multichain-sign-sk-dev-2"
     sk_share_secret_id   = "multichain-sk-share-dev-2"
   }
 ]

--- a/infra/multichain-dev/variables.tf
+++ b/infra/multichain-dev/variables.tf
@@ -44,6 +44,7 @@ variable "node_configs" {
     address              = string
     account_sk_secret_id = string
     cipher_sk_secret_id  = string
+    sign_sk_secret_id    = string
     sk_share_secret_id   = string
   }))
 }

--- a/infra/multichain-prod/main.tf
+++ b/infra/multichain-prod/main.tf
@@ -99,10 +99,10 @@ resource "google_secret_manager_secret_iam_member" "sk_share_secret_manager" {
 }
 
 resource "google_project_iam_member" "datastore_iam_member" {
-  count = length(var.node_configs)
-  project   = var.project
-  role      = "roles/datastore.user"
-  member    = "serviceAccount:${google_service_account.service_account.email}"
+  count   = length(var.node_configs)
+  project = var.project
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.service_account.email}"
 }
 
 module "node" {
@@ -126,6 +126,7 @@ module "node" {
 
   account_sk_secret_id     = var.node_configs[count.index].account_sk_secret_id
   cipher_sk_secret_id      = var.node_configs[count.index].cipher_sk_secret_id
+  sign_sk_secret_id        = var.node_configs[count.index].sign_sk_secret_id
   aws_access_key_secret_id = var.aws_access_key_secret_id
   aws_secret_key_secret_id = var.aws_secret_key_secret_id
   sk_share_secret_id       = var.node_configs[count.index].sk_share_secret_id
@@ -133,6 +134,7 @@ module "node" {
   depends_on = [
     google_secret_manager_secret_iam_member.account_sk_secret_access,
     google_secret_manager_secret_iam_member.cipher_sk_secret_access,
+    google_secret_manager_secret_iam_member.sign_sk_secret_access,
     google_secret_manager_secret_iam_member.aws_access_key_secret_access,
     google_secret_manager_secret_iam_member.aws_secret_key_secret_access,
     google_secret_manager_secret_iam_member.sk_share_secret_access,

--- a/infra/multichain-prod/variables.tf
+++ b/infra/multichain-prod/variables.tf
@@ -44,6 +44,7 @@ variable "node_configs" {
     address              = string
     account_sk_secret_id = string
     cipher_sk_secret_id  = string
+    sign_sk_secret_id    = string
     sk_share_secret_id   = string
   }))
 }

--- a/infra/multichain-testnet-prod/main.tf
+++ b/infra/multichain-testnet-prod/main.tf
@@ -36,6 +36,10 @@ module "gce-container" {
         value = data.google_secret_manager_secret_version.cipher_sk_secret_id[count.index].secret_data
       },
       {
+        name  = "MPC_RECOVERY_SIGN_SK"
+        value = data.google_secret_manager_secret_version.sign_sk_secret_id[count.index].secret_data
+      },
+      {
         name  = "AWS_ACCESS_KEY_ID"
         value = data.google_secret_manager_secret_version.aws_access_key_secret_id.secret_data
       },
@@ -48,16 +52,16 @@ module "gce-container" {
         value = "http://${google_compute_global_address.external_ips[count.index].address}"
       },
       {
-        name = "MPC_RECOVERY_SK_SHARE_SECRET_ID"
+        name  = "MPC_RECOVERY_SK_SHARE_SECRET_ID"
         value = var.node_configs["${count.index}"].sk_share_secret_id
       },
       {
-        name = "MPC_RECOVERY_ENV",
+        name  = "MPC_RECOVERY_ENV",
         value = var.env
       },
       {
-      name  = "MPC_RECOVERY_GCP_PROJECT_ID"
-      value = var.project_id
+        name  = "MPC_RECOVERY_GCP_PROJECT_ID"
+        value = var.project_id
       },
     ])
   }
@@ -70,17 +74,17 @@ resource "google_service_account" "service_account" {
 
 resource "google_project_iam_binding" "sa-roles" {
   for_each = toset([
-      "roles/datastore.user",
-      "roles/secretmanager.admin",
-      "roles/storage.objectAdmin",
-      "roles/iam.serviceAccountAdmin",
+    "roles/datastore.user",
+    "roles/secretmanager.admin",
+    "roles/storage.objectAdmin",
+    "roles/iam.serviceAccountAdmin",
   ])
 
   role = each.key
-  members = [ 
+  members = [
     "serviceAccount:${google_service_account.service_account.email}"
-   ]
-   project = var.project_id
+  ]
+  project = var.project_id
 }
 
 resource "google_compute_global_address" "external_ips" {
@@ -144,16 +148,16 @@ resource "google_compute_health_check" "multichain_healthcheck" {
 }
 
 resource "google_compute_global_forwarding_rule" "default" {
-  count      = length(var.node_configs)
-  name       = "multichain-partner-rule-${count.index}"
-  target     = google_compute_target_http_proxy.default[count.index].id
-  port_range = "80"
+  count                 = length(var.node_configs)
+  name                  = "multichain-partner-rule-${count.index}"
+  target                = google_compute_target_http_proxy.default[count.index].id
+  port_range            = "80"
   load_balancing_scheme = "EXTERNAL"
-  ip_address = google_compute_global_address.external_ips[count.index].address
+  ip_address            = google_compute_global_address.external_ips[count.index].address
 }
 
 resource "google_compute_target_http_proxy" "default" {
-  count      = length(var.node_configs)
+  count       = length(var.node_configs)
   name        = "multichain-partner-target-proxy-${count.index}"
   description = "a description"
   url_map     = google_compute_url_map.default[count.index].id

--- a/infra/multichain-testnet-prod/resources.tf
+++ b/infra/multichain-testnet-prod/resources.tf
@@ -25,6 +25,12 @@ data "google_secret_manager_secret_version" "cipher_sk_secret_id" {
   project = var.project_id
 }
 
+data "google_secret_manager_secret_version" "sign_sk_secret_id" {
+  count   = length(var.node_configs)
+  secret  = var.node_configs[0].sign_sk_secret_id
+  project = var.project_id
+}
+
 data "google_secret_manager_secret_version" "sk_share_secret_id" {
   count   = length(var.node_configs)
   secret  = var.node_configs[0].sk_share_secret_id

--- a/infra/multichain-testnet-prod/variables.tf
+++ b/infra/multichain-testnet-prod/variables.tf
@@ -68,12 +68,13 @@ variable "node_configs" {
     cipher_pk            = string
     account_sk_secret_id = string
     cipher_sk_secret_id  = string
+    sign_sk_secret_id    = string
     sk_share_secret_id   = string
   }))
 }
 
 variable "env" {
-  type = string
+  type    = string
   default = "dev"
 }
 
@@ -119,6 +120,6 @@ variable "static_env" {
 }
 
 variable "create_network" {
-  default = false
+  default     = false
   description = "Do you want to create a new VPC network (true) or use default GCP network (false)?"
 }

--- a/infra/multichain-testnet/main.tf
+++ b/infra/multichain-testnet/main.tf
@@ -70,6 +70,14 @@ resource "google_secret_manager_secret_iam_member" "cipher_sk_secret_access" {
   member    = "serviceAccount:${google_service_account.service_account.email}"
 }
 
+resource "google_secret_manager_secret_iam_member" "sign_sk_secret_access" {
+  count = length(var.node_configs)
+
+  secret_id = var.node_configs[count.index].sign_sk_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.service_account.email}"
+}
+
 resource "google_secret_manager_secret_iam_member" "aws_access_key_secret_access" {
   secret_id = var.aws_access_key_secret_id
   role      = "roles/secretmanager.secretAccessor"
@@ -99,10 +107,10 @@ resource "google_secret_manager_secret_iam_member" "sk_share_secret_manager" {
 }
 
 resource "google_project_iam_member" "datastore_iam_member" {
-  count = length(var.node_configs)
-  project   = var.project
-  role      = "roles/datastore.user"
-  member    = "serviceAccount:${google_service_account.service_account.email}"
+  count   = length(var.node_configs)
+  project = var.project
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.service_account.email}"
 }
 
 module "node" {
@@ -126,6 +134,7 @@ module "node" {
 
   account_sk_secret_id     = var.node_configs[count.index].account_sk_secret_id
   cipher_sk_secret_id      = var.node_configs[count.index].cipher_sk_secret_id
+  sign_sk_secret_id        = var.node_configs[count.index].sign_sk_secret_id
   aws_access_key_secret_id = var.aws_access_key_secret_id
   aws_secret_key_secret_id = var.aws_secret_key_secret_id
   sk_share_secret_id       = var.node_configs[count.index].sk_share_secret_id
@@ -133,6 +142,7 @@ module "node" {
   depends_on = [
     google_secret_manager_secret_iam_member.account_sk_secret_access,
     google_secret_manager_secret_iam_member.cipher_sk_secret_access,
+    google_secret_manager_secret_iam_member.sign_sk_secret_access,
     google_secret_manager_secret_iam_member.aws_access_key_secret_access,
     google_secret_manager_secret_iam_member.aws_secret_key_secret_access,
     google_secret_manager_secret_iam_member.sk_share_secret_access,

--- a/infra/multichain-testnet/variables.tf
+++ b/infra/multichain-testnet/variables.tf
@@ -39,11 +39,12 @@ variable "indexer_options" {
 
 variable "node_configs" {
   type = list(object({
-    account_id            = string
+    account_id           = string
     cipher_pk            = string
     address              = string
     account_sk_secret_id = string
     cipher_sk_secret_id  = string
+    sign_sk_secret_id    = string
     sk_share_secret_id   = string
   }))
 }

--- a/infra/multichain-vm-dev/main.tf
+++ b/infra/multichain-vm-dev/main.tf
@@ -36,6 +36,10 @@ module "gce-container" {
         value = data.google_secret_manager_secret_version.cipher_sk_secret_id[count.index].secret_data
       },
       {
+        name  = "MPC_RECOVERY_SIGN_SK"
+        value = data.google_secret_manager_secret_version.sign_sk_secret_id[count.index].secret_data
+      },
+      {
         name  = "AWS_ACCESS_KEY_ID"
         value = data.google_secret_manager_secret_version.aws_access_key_secret_id.secret_data
       },
@@ -48,11 +52,11 @@ module "gce-container" {
         value = "http://${google_compute_address.internal_ips[count.index].address}"
       },
       {
-        name = "MPC_RECOVERY_SK_SHARE_SECRET_ID"
+        name  = "MPC_RECOVERY_SK_SHARE_SECRET_ID"
         value = var.node_configs["${count.index}"].sk_share_secret_id
       },
       {
-        name = "MPC_RECOVERY_ENV",
+        name  = "MPC_RECOVERY_ENV",
         value = var.env
       }
     ])

--- a/infra/multichain-vm-dev/resources.tf
+++ b/infra/multichain-vm-dev/resources.tf
@@ -24,6 +24,12 @@ data "google_secret_manager_secret_version" "cipher_sk_secret_id" {
   project = var.project_id
 }
 
+data "google_secret_manager_secret_version" "sign_sk_secret_id" {
+  count   = length(var.node_configs)
+  secret  = "multichain-sign-sk-dev-${count.index}"
+  project = var.project_id
+}
+
 data "google_secret_manager_secret_version" "sk_share_secret_id" {
   count   = length(var.node_configs)
   secret  = "multichain-sk-share-dev-${count.index}"

--- a/infra/multichain-vm-dev/terraform-dev.tfvars
+++ b/infra/multichain-vm-dev/terraform-dev.tfvars
@@ -1,10 +1,11 @@
-env          = "dev"
+env = "dev"
 node_configs = [
   {
     account              = "multichain-node-dev-0.testnet"
     cipher_pk            = "5a9d1d27fc3c952e7af7a2f1c84f552928eec232c3f2c3e787f4a15d82a82916"
     account_sk_secret_id = "multichain-account-sk-dev-0"
     cipher_sk_secret_id  = "multichain-cipher-sk-dev-0"
+    sign_sk_secret_id    = "multichain-sign-sk-dev-0"
     sk_share_secret_id   = "multichain-sk-share-dev-0"
   },
   {
@@ -12,6 +13,7 @@ node_configs = [
     cipher_pk            = "349f89f6717a02aaf7a649b98ac7af09e6517ffd4cb7ea8a9f6edee8f84a330c"
     account_sk_secret_id = "multichain-account-sk-dev-1"
     cipher_sk_secret_id  = "multichain-cipher-sk-dev-1"
+    sign_sk_secret_id    = "multichain-sign-sk-dev-1"
     sk_share_secret_id   = "multichain-sk-share-dev-1"
   },
   {
@@ -19,6 +21,7 @@ node_configs = [
     cipher_pk            = "78ae67d38afaa6d329bba0175c200a8c248a5a82d78fbb8f71e060e6c186d800"
     account_sk_secret_id = "multichain-account-sk-dev-2"
     cipher_sk_secret_id  = "multichain-cipher-sk-dev-2"
+    sign_sk_secret_id    = "multichain-sign-sk-dev-2"
     sk_share_secret_id   = "multichain-sk-share-dev-2"
   },
   {
@@ -26,6 +29,7 @@ node_configs = [
     cipher_pk            = "f0bc3ec25105301e0dfaafffb043fafd98b520692610bf09d688b77a3de4f16e"
     account_sk_secret_id = "multichain-account-sk-dev-3"
     cipher_sk_secret_id  = "multichain-cipher-sk-dev-3"
+    sign_sk_secret_id    = "multichain-sign-sk-dev-3"
     sk_share_secret_id   = "multichain-sk-share-dev-3"
   },
   {
@@ -33,6 +37,7 @@ node_configs = [
     cipher_pk            = "4d4df6855b2b3825ed2b7f4becfbe2ea7c940817bb54eaa5c4baef7c73df426b"
     account_sk_secret_id = "multichain-account-sk-dev-4"
     cipher_sk_secret_id  = "multichain-cipher-sk-dev-4"
+    sign_sk_secret_id    = "multichain-sign-sk-dev-4"
     sk_share_secret_id   = "multichain-sk-share-dev-4"
   },
   {
@@ -40,6 +45,7 @@ node_configs = [
     cipher_pk            = "9c228aedc6bd9c49f7cbbfebe68a61e2ecb5ba015fde8ec178b798d022fec528"
     account_sk_secret_id = "multichain-account-sk-dev-5"
     cipher_sk_secret_id  = "multichain-cipher-sk-dev-5"
+    sign_sk_secret_id    = "multichain-sign-sk-dev-5"
     sk_share_secret_id   = "multichain-sk-share-dev-5"
   },
   {
@@ -47,6 +53,7 @@ node_configs = [
     cipher_pk            = "490cdcec451c9d34d186af4b0747f82c3dbc45df0d9a6d4b8cd68a783592073b"
     account_sk_secret_id = "multichain-account-sk-dev-6"
     cipher_sk_secret_id  = "multichain-cipher-sk-dev-6"
+    sign_sk_secret_id    = "multichain-sign-sk-dev-6"
     sk_share_secret_id   = "multichain-sk-share-dev-6"
   },
   {
@@ -54,6 +61,7 @@ node_configs = [
     cipher_pk            = "5f49047f95ab9705f325d573ea6fcd2bbe681ab1f90b6b0d736669c34b483a07"
     account_sk_secret_id = "multichain-account-sk-dev-7"
     cipher_sk_secret_id  = "multichain-cipher-sk-dev-7"
+    sign_sk_secret_id    = "multichain-sign-sk-dev-7"
     sk_share_secret_id   = "multichain-sk-share-dev-7"
   },
 ]

--- a/infra/multichain-vm-dev/variables.tf
+++ b/infra/multichain-vm-dev/variables.tf
@@ -68,6 +68,7 @@ variable "node_configs" {
     cipher_pk            = string
     account_sk_secret_id = string
     cipher_sk_secret_id  = string
+    sign_sk_secret_id    = string
     sk_share_secret_id   = string
   }))
 }

--- a/infra/multichain-vm-testnet-deprecated/main.tf
+++ b/infra/multichain-vm-testnet-deprecated/main.tf
@@ -36,6 +36,10 @@ module "gce-container" {
         value = data.google_secret_manager_secret_version.cipher_sk_secret_id[count.index].secret_data
       },
       {
+        name  = "MPC_RECOVERY_SIGN_SK"
+        value = data.google_secret_manager_secret_version.sign_sk_secret_id[count.index].secret_data
+      },
+      {
         name  = "AWS_ACCESS_KEY_ID"
         value = data.google_secret_manager_secret_version.aws_access_key_secret_id.secret_data
       },

--- a/infra/multichain-vm-testnet-deprecated/resources.tf
+++ b/infra/multichain-vm-testnet-deprecated/resources.tf
@@ -24,6 +24,12 @@ data "google_secret_manager_secret_version" "cipher_sk_secret_id" {
   project = var.project_id
 }
 
+data "google_secret_manager_secret_version" "sign_sk_secret_id" {
+  count   = length(var.node_configs)
+  secret  = "multichain-sign-sk-testnet-${count.index}"
+  project = var.project_id
+}
+
 data "google_secret_manager_secret_version" "sk_share_secret_id" {
   count   = length(var.node_configs)
   secret  = "multichain-sk-share-testnet-${count.index}"

--- a/infra/multichain-vm-testnet-deprecated/variables.tf
+++ b/infra/multichain-vm-testnet-deprecated/variables.tf
@@ -68,12 +68,13 @@ variable "node_configs" {
     cipher_pk            = string
     account_sk_secret_id = string
     cipher_sk_secret_id  = string
+    sign_sk_secret_id    = string
     sk_share_secret_id   = string
   }))
 }
 
 variable "env" {
-  type = string
+  type    = string
   default = "testnet"
 }
 

--- a/infra/partner-vm-testnet/main.tf
+++ b/infra/partner-vm-testnet/main.tf
@@ -36,6 +36,10 @@ module "gce-container" {
         value = data.google_secret_manager_secret_version.cipher_sk_secret_id[count.index].secret_data
       },
       {
+        name  = "MPC_RECOVERY_SIGN_SK"
+        value = data.google_secret_manager_secret_version.sign_sk_secret_id[count.index].secret_data
+      },
+      {
         name  = "AWS_ACCESS_KEY_ID"
         value = data.google_secret_manager_secret_version.aws_access_key_secret_id.secret_data
       },
@@ -73,7 +77,7 @@ resource "google_project_iam_binding" "sa-roles" {
   ])
 
   role = each.key
-  members = [ 
+  members = [
     "serviceAccount:${google_service_account.service_account.email}"
    ]
    project = var.project_id
@@ -194,5 +198,5 @@ resource "google_compute_firewall" "app_port" {
     protocol = "tcp"
     ports = [ "80", "3000" ]
   }
-  
+
 }

--- a/infra/partner-vm-testnet/resources.tf
+++ b/infra/partner-vm-testnet/resources.tf
@@ -25,6 +25,12 @@ data "google_secret_manager_secret_version" "cipher_sk_secret_id" {
   project = var.project_id
 }
 
+data "google_secret_manager_secret_version" "sign_sk_secret_id" {
+  count   = length(var.node_configs)
+  secret  = var.node_configs[0].sign_sk_secret_id
+  project = var.project_id
+}
+
 data "google_secret_manager_secret_version" "sk_share_secret_id" {
   count   = length(var.node_configs)
   secret  = var.node_configs[0].sk_share_secret_id

--- a/infra/partner-vm-testnet/terraform-testnet-example.tfvars
+++ b/infra/partner-vm-testnet/terraform-testnet-example.tfvars
@@ -14,6 +14,7 @@ node_configs = [
     # These 3 values below should match your secret names in google secrets manager
     account_sk_secret_id = "multichain-account-sk-testnet-0"
     cipher_sk_secret_id  = "multichain-cipher-sk-testnet-0"
+    sign_sk_secret_id    = "multichain-sign-sk-testnet-0"
     sk_share_secret_id   = "multichain-sk-share-testnet-0"
   },
 ]

--- a/infra/partner-vm-testnet/variables.tf
+++ b/infra/partner-vm-testnet/variables.tf
@@ -68,6 +68,7 @@ variable "node_configs" {
     cipher_pk            = string
     account_sk_secret_id = string
     cipher_sk_secret_id  = string
+    sign_sk_secret_id    = string
     sk_share_secret_id   = string
   }))
 }

--- a/integration-tests/src/multichain/containers.rs
+++ b/integration-tests/src/multichain/containers.rs
@@ -42,6 +42,8 @@ impl<'a> Node<'a> {
     ) -> anyhow::Result<Node<'a>> {
         tracing::info!("running node container, account_id={}", account_id);
         let (cipher_sk, cipher_pk) = hpke::generate();
+        let sign_sk =
+            near_crypto::SecretKey::from_seed(near_crypto::KeyType::ED25519, "integration-test");
         let storage_options = ctx.storage_options.clone();
         let args = mpc_recovery_node::cli::Cli::Start {
             near_rpc: ctx.lake_indexer.rpc_host_address.clone(),
@@ -51,6 +53,7 @@ impl<'a> Node<'a> {
             web_port: Self::CONTAINER_PORT,
             cipher_pk: hex::encode(cipher_pk.to_bytes()),
             cipher_sk: hex::encode(cipher_sk.to_bytes()),
+            sign_sk: sign_sk.to_string(),
             indexer_options: mpc_recovery_node::indexer::Options {
                 s3_bucket: ctx.localstack.s3_bucket.clone(),
                 s3_region: ctx.localstack.s3_region.clone(),

--- a/integration-tests/src/multichain/local.rs
+++ b/integration-tests/src/multichain/local.rs
@@ -28,6 +28,8 @@ impl Node {
     ) -> anyhow::Result<Self> {
         let web_port = util::pick_unused_port().await?;
         let (cipher_sk, cipher_pk) = hpke::generate();
+        let sign_sk =
+            near_crypto::SecretKey::from_seed(near_crypto::KeyType::ED25519, "integration-test");
         let storage_options = ctx.storage_options.clone();
         let cli = mpc_recovery_node::cli::Cli::Start {
             near_rpc: ctx.lake_indexer.rpc_host_address.clone(),
@@ -37,6 +39,7 @@ impl Node {
             web_port,
             cipher_pk: hex::encode(cipher_pk.to_bytes()),
             cipher_sk: hex::encode(cipher_sk.to_bytes()),
+            sign_sk: sign_sk.to_string(),
             indexer_options: mpc_recovery_node::indexer::Options {
                 s3_bucket: ctx.localstack.s3_bucket.clone(),
                 s3_region: ctx.localstack.s3_region.clone(),

--- a/node/src/mesh/mod.rs
+++ b/node/src/mesh/mod.rs
@@ -1,7 +1,24 @@
+use mpc_keys::hpke;
+
 use crate::protocol::contract::primitives::Participants;
 use crate::protocol::ProtocolState;
 
 pub mod connection;
+
+#[derive(Clone, Debug)]
+pub struct NetworkConfig {
+    pub sign_sk: near_crypto::SecretKey,
+    pub cipher_pk: hpke::PublicKey,
+}
+
+impl NetworkConfig {
+    pub fn test() -> Self {
+        Self {
+            sign_sk: near_crypto::SecretKey::from_seed(near_crypto::KeyType::ED25519, "test"),
+            cipher_pk: hpke::PublicKey::from_bytes(&[0; 32]),
+        }
+    }
+}
 
 #[derive(Default)]
 pub struct Mesh {

--- a/node/src/protocol/mod.rs
+++ b/node/src/protocol/mod.rs
@@ -22,7 +22,7 @@ use self::cryptography::CryptographicCtx;
 use self::message::MessageCtx;
 use self::presignature::PresignatureConfig;
 use self::triple::TripleConfig;
-use crate::mesh::Mesh;
+use crate::mesh::{Mesh, NetworkConfig};
 use crate::protocol::consensus::ConsensusProtocol;
 use crate::protocol::cryptography::CryptographicProtocol;
 use crate::protocol::message::{MessageHandler, MpcMessageQueue};
@@ -40,12 +40,11 @@ use tokio::sync::mpsc::{self, error::TryRecvError};
 use tokio::sync::RwLock;
 use url::Url;
 
-use mpc_keys::hpke;
-
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct Config {
     pub triple_cfg: TripleConfig,
     pub presig_cfg: PresignatureConfig,
+    pub network_cfg: NetworkConfig,
 }
 
 struct Ctx {
@@ -56,8 +55,6 @@ struct Ctx {
     rpc_client: near_fetch::Client,
     http_client: reqwest::Client,
     sign_queue: Arc<RwLock<SignQueue>>,
-    cipher_pk: hpke::PublicKey,
-    sign_sk: near_crypto::SecretKey,
     secret_storage: SecretNodeStorageBox,
     triple_storage: LockTripleNodeStorageBox,
     cfg: Config,
@@ -93,27 +90,15 @@ impl ConsensusCtx for &mut MpcSignProtocol {
         self.ctx.sign_queue.clone()
     }
 
-    fn cipher_pk(&self) -> &hpke::PublicKey {
-        &self.ctx.cipher_pk
-    }
-
-    fn sign_pk(&self) -> near_crypto::PublicKey {
-        self.ctx.sign_sk.public_key()
-    }
-
-    fn sign_sk(&self) -> &near_crypto::SecretKey {
-        &self.ctx.sign_sk
-    }
-
     fn secret_storage(&self) -> &SecretNodeStorageBox {
         &self.ctx.secret_storage
     }
 
-    fn cfg(&self) -> Config {
-        self.ctx.cfg
+    fn cfg(&self) -> &Config {
+        &self.ctx.cfg
     }
 
-    fn triple_storage(&mut self) -> LockTripleNodeStorageBox {
+    fn triple_storage(&self) -> LockTripleNodeStorageBox {
         self.ctx.triple_storage.clone()
     }
 }
@@ -140,16 +125,12 @@ impl CryptographicCtx for &mut MpcSignProtocol {
         &self.ctx.mpc_contract_id
     }
 
-    fn cipher_pk(&self) -> &hpke::PublicKey {
-        &self.ctx.cipher_pk
-    }
-
-    fn sign_sk(&self) -> &near_crypto::SecretKey {
-        &self.ctx.sign_sk
-    }
-
     fn secret_storage(&mut self) -> &mut SecretNodeStorageBox {
         &mut self.ctx.secret_storage
+    }
+
+    fn cfg(&self) -> &Config {
+        &self.ctx.cfg
     }
 
     fn mesh(&self) -> &Mesh {
@@ -184,7 +165,6 @@ impl MpcSignProtocol {
         signer: InMemorySigner,
         receiver: mpsc::Receiver<MpcMessage>,
         sign_queue: Arc<RwLock<SignQueue>>,
-        cipher_pk: hpke::PublicKey,
         secret_storage: SecretNodeStorageBox,
         triple_storage: LockTripleNodeStorageBox,
         cfg: Config,
@@ -197,8 +177,6 @@ impl MpcSignProtocol {
             rpc_client,
             http_client: reqwest::Client::new(),
             sign_queue,
-            cipher_pk,
-            sign_sk: signer.secret_key.clone(),
             signer,
             secret_storage,
             triple_storage,

--- a/node/src/protocol/presignature.rs
+++ b/node/src/protocol/presignature.rs
@@ -1,6 +1,5 @@
 use super::message::PresignatureMessage;
 use super::triple::{Triple, TripleConfig, TripleId, TripleManager};
-use super::Config;
 use crate::gcp::error::DatastoreStorageError;
 use crate::protocol::contract::primitives::Participants;
 use crate::types::{PresignatureProtocol, PublicKey, SecretKeyShare};
@@ -116,7 +115,7 @@ impl PresignatureManager {
         threshold: usize,
         epoch: u64,
         my_account_id: &AccountId,
-        cfg: Config,
+        presig_cfg: &PresignatureConfig,
     ) -> Self {
         Self {
             presignatures: HashMap::new(),
@@ -128,7 +127,7 @@ impl PresignatureManager {
             threshold,
             epoch,
             my_account_id: my_account_id.clone(),
-            presig_cfg: cfg.presig_cfg,
+            presig_cfg: *presig_cfg,
         }
     }
 

--- a/node/src/protocol/triple.rs
+++ b/node/src/protocol/triple.rs
@@ -2,7 +2,6 @@ use super::contract::primitives::Participants;
 use super::cryptography::CryptographicError;
 use super::message::TripleMessage;
 use super::presignature::GenerationError;
-use super::Config;
 use crate::gcp::error;
 use crate::storage::triple_storage::{LockTripleNodeStorageBox, TripleData};
 use crate::types::TripleProtocol;
@@ -120,7 +119,7 @@ impl TripleManager {
         me: Participant,
         threshold: usize,
         epoch: u64,
-        cfg: Config,
+        triple_cfg: &TripleConfig,
         triple_data: Vec<TripleData>,
         triple_storage: LockTripleNodeStorageBox,
         my_account_id: &AccountId,
@@ -146,7 +145,7 @@ impl TripleManager {
             me,
             threshold,
             epoch,
-            triple_cfg: cfg.triple_cfg,
+            triple_cfg: *triple_cfg,
             triple_storage,
             failed_triples: HashMap::new(),
             my_account_id: my_account_id.clone(),

--- a/node/src/test_utils.rs
+++ b/node/src/test_utils.rs
@@ -1,7 +1,7 @@
 use crate::protocol::contract::primitives::Participants;
-use crate::protocol::presignature::{GenerationError, PresignatureConfig};
+use crate::protocol::presignature::GenerationError;
 use crate::protocol::triple::{Triple, TripleConfig, TripleId, TripleManager};
-use crate::protocol::{Config, ParticipantInfo};
+use crate::protocol::ParticipantInfo;
 use crate::storage::triple_storage::LockTripleNodeStorageBox;
 use crate::{gcp::GcpService, protocol::message::TripleMessage, storage};
 
@@ -16,17 +16,11 @@ use tokio::sync::RwLock;
 
 // Constants to be used for testing.
 const STARTING_EPOCH: u64 = 0;
-const DEFAULT_TEST_CONFIG: Config = Config {
-    triple_cfg: TripleConfig {
-        min_triples: 2,
-        max_triples: 10,
-        max_concurrent_introduction: 4,
-        max_concurrent_generation: 16,
-    },
-    presig_cfg: PresignatureConfig {
-        min_presignatures: 2,
-        max_presignatures: 10,
-    },
+const TRIPLE_CFG: TripleConfig = TripleConfig {
+    min_triples: 2,
+    max_triples: 10,
+    max_concurrent_introduction: 4,
+    max_concurrent_generation: 16,
 };
 
 struct TestTripleManagers {
@@ -72,7 +66,7 @@ impl TestTripleManagers {
                     Participant::from(num),
                     num_managers as usize,
                     STARTING_EPOCH,
-                    DEFAULT_TEST_CONFIG,
+                    &TRIPLE_CFG,
                     vec![],
                     triple_storage,
                     &account_id,


### PR DESCRIPTION
This introduces a separate signing key for messages to be sent over the wire for protocols like triple, presignature and signature generation. @ppca this also adds in `multichain-sign-sk-*` to terraform so this introduces a new key needed to be added by partner nodes. This key can be generated via: 
```rs

    #[test]
    fn test() {
        let sk = near_crypto::SecretKey::from_random(near_crypto::KeyType::ED25519);
        println!("{sk}");
    }
```
