### PR TITLE
fix: only retry signature generators with proposer = me

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -387,7 +387,7 @@ impl MpcContract {
                     // Make sure we have enough gas left to do 1 more call and clean up afterwards
                     // Observationally 30 calls < 300 TGas so 2 calls < 20 TGas
                     // We keep one call back so we can cleanup then call panic on the next call
-                    if depth > 29 {
+                    if depth > 129 {
                         self.remove_request(&payload);
                         let self_id = env::current_account_id();
                         PromiseOrValue::Promise(Self::ext(self_id).fail_helper(

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -387,7 +387,7 @@ impl MpcContract {
                     // Make sure we have enough gas left to do 1 more call and clean up afterwards
                     // Observationally 30 calls < 300 TGas so 2 calls < 20 TGas
                     // We keep one call back so we can cleanup then call panic on the next call
-                    if depth > 129 {
+                    if depth > 29 {
                         self.remove_request(&payload);
                         let self_id = env::current_account_id();
                         PromiseOrValue::Promise(Self::ext(self_id).fail_helper(

--- a/integration-tests/tests/multichain/actions/wait_for.rs
+++ b/integration-tests/tests/multichain/actions/wait_for.rs
@@ -86,6 +86,44 @@ pub async fn has_at_least_triples<'a>(
     Ok(state_views)
 }
 
+pub async fn has_at_least_mine_triples<'a>(
+    ctx: &MultichainTestContext<'a>,
+    expected_mine_triple_count: usize,
+) -> anyhow::Result<Vec<StateView>> {
+    let is_enough_mine_triples = |id| {
+        move || async move {
+            let state_view: StateView = ctx
+                .http_client
+                .get(format!("{}/state", ctx.nodes.url(id)))
+                .send()
+                .await?
+                .json()
+                .await?;
+
+            match state_view {
+                StateView::Running { triple_mine_count, .. }
+                    if triple_mine_count >= expected_mine_triple_count =>
+                {
+                    Ok(state_view)
+                }
+                StateView::Running { .. } => anyhow::bail!("node does not have enough mine triples yet"),
+                StateView::NotRunning => anyhow::bail!("node is not running"),
+            }
+        }
+    };
+
+    let mut state_views = Vec::new();
+    for id in 0..ctx.nodes.len() {
+        let state_view = is_enough_mine_triples(id)
+            .retry(&ExponentialBuilder::default().with_max_times(15))
+            .await
+            .with_context(|| format!("mpc node '{id}' failed to generate '{expected_mine_triple_count}' triples before deadline"))?;
+        state_views.push(state_view);
+    }
+    Ok(state_views)
+}
+
+
 pub async fn has_at_least_presignatures<'a>(
     ctx: &MultichainTestContext<'a>,
     expected_presignature_count: usize,
@@ -118,6 +156,43 @@ pub async fn has_at_least_presignatures<'a>(
             .retry(&ExponentialBuilder::default().with_max_times(6))
             .await
             .with_context(|| format!("mpc node '{id}' failed to generate '{expected_presignature_count}' presignatures before deadline"))?;
+        state_views.push(state_view);
+    }
+    Ok(state_views)
+}
+
+pub async fn has_at_least_mine_presignatures<'a>(
+    ctx: &MultichainTestContext<'a>,
+    expected_mine_presignature_count: usize,
+) -> anyhow::Result<Vec<StateView>> {
+    let is_enough_mine_presignatures = |id| {
+        move || async move {
+            let state_view: StateView = ctx
+                .http_client
+                .get(format!("{}/state", ctx.nodes.url(id)))
+                .send()
+                .await?
+                .json()
+                .await?;
+
+            match state_view {
+                StateView::Running {
+                    presignature_mine_count, ..
+                } if presignature_mine_count >= expected_mine_presignature_count => Ok(state_view),
+                StateView::Running { .. } => {
+                    anyhow::bail!("node does not have enough mine presignatures yet")
+                }
+                StateView::NotRunning => anyhow::bail!("node is not running"),
+            }
+        }
+    };
+
+    let mut state_views = Vec::new();
+    for id in 0..ctx.nodes.len() {
+        let state_view = is_enough_mine_presignatures(id)
+            .retry(&ExponentialBuilder::default().with_max_times(6))
+            .await
+            .with_context(|| format!("mpc node '{id}' failed to generate '{expected_mine_presignature_count}' presignatures before deadline"))?;
         state_views.push(state_view);
     }
     Ok(state_views)

--- a/integration-tests/tests/multichain/actions/wait_for.rs
+++ b/integration-tests/tests/multichain/actions/wait_for.rs
@@ -101,12 +101,12 @@ pub async fn has_at_least_mine_triples<'a>(
                 .await?;
 
             match state_view {
-                StateView::Running { triple_mine_count, .. }
-                    if triple_mine_count >= expected_mine_triple_count =>
-                {
-                    Ok(state_view)
+                StateView::Running {
+                    triple_mine_count, ..
+                } if triple_mine_count >= expected_mine_triple_count => Ok(state_view),
+                StateView::Running { .. } => {
+                    anyhow::bail!("node does not have enough mine triples yet")
                 }
-                StateView::Running { .. } => anyhow::bail!("node does not have enough mine triples yet"),
                 StateView::NotRunning => anyhow::bail!("node is not running"),
             }
         }
@@ -122,7 +122,6 @@ pub async fn has_at_least_mine_triples<'a>(
     }
     Ok(state_views)
 }
-
 
 pub async fn has_at_least_presignatures<'a>(
     ctx: &MultichainTestContext<'a>,
@@ -177,7 +176,8 @@ pub async fn has_at_least_mine_presignatures<'a>(
 
             match state_view {
                 StateView::Running {
-                    presignature_mine_count, ..
+                    presignature_mine_count,
+                    ..
                 } if presignature_mine_count >= expected_mine_presignature_count => Ok(state_view),
                 StateView::Running { .. } => {
                     anyhow::bail!("node does not have enough mine presignatures yet")

--- a/integration-tests/tests/multichain/mod.rs
+++ b/integration-tests/tests/multichain/mod.rs
@@ -68,7 +68,8 @@ async fn test_signature_offline_node() -> anyhow::Result<()> {
         Box::pin(async move {
             let state_0 = wait_for::running_mpc(&ctx, Some(0)).await?;
             assert_eq!(state_0.participants.len(), 3);
-            wait_for::has_at_least_triples(&ctx, 4).await?;
+            wait_for::has_at_least_triples(&ctx, 6).await?;
+            wait_for::has_at_least_mine_triples(&ctx, 2).await?;
 
             // Kill the node then have presignature and signature generation only use the active set of nodes
             // to start generating presignatures and signatures.
@@ -81,14 +82,14 @@ async fn test_signature_offline_node() -> anyhow::Result<()> {
             // This could potentially fail and timeout the first time if the participant set picked up is the
             // one with the offline node. This is expected behavior for now if a user submits a request in between
             // a node going offline and the system hasn't detected it yet.
-            let presig_res = wait_for::has_at_least_presignatures(&ctx, 2).await;
+            let presig_res = wait_for::has_at_least_mine_presignatures(&ctx, 1).await;
             let sig_res = actions::single_signature_production(&ctx, &state_0).await;
 
             // Try again if the first attempt failed. This second portion should not be needed when the NEP
             // comes in for resumeable MPC.
             if presig_res.is_err() || sig_res.is_err() {
                 // Retry if the first attempt failed.
-                wait_for::has_at_least_presignatures(&ctx, 2).await?;
+                wait_for::has_at_least_mine_presignatures(&ctx, 1).await?;
                 actions::single_signature_production(&ctx, &state_0).await?;
             }
 

--- a/node/src/protocol/cryptography.rs
+++ b/node/src/protocol/cryptography.rs
@@ -406,7 +406,7 @@ impl CryptographicProtocol for RunningState {
             if let Some((receipt_id, failed_generator)) = signature_manager.take_failed_generator()
             {
                 // only retry the failed signature generator if the proposer of the signature is me
-                if true {
+                if failed_generator.proposer == signature_manager.me() {
                     let Some(presignature) = presignature_manager.take_mine() else {
                         break;
                     };

--- a/node/src/protocol/cryptography.rs
+++ b/node/src/protocol/cryptography.rs
@@ -406,7 +406,7 @@ impl CryptographicProtocol for RunningState {
             if let Some((receipt_id, failed_generator)) = signature_manager.take_failed_generator()
             {
                 // only retry the failed signature generator if the proposer of the signature is me
-                if failed_generator.proposer == signature_manager.me() {
+                if true {
                     let Some(presignature) = presignature_manager.take_mine() else {
                         break;
                     };

--- a/node/src/protocol/signature.rs
+++ b/node/src/protocol/signature.rs
@@ -200,6 +200,10 @@ impl SignatureManager {
         self.failed_generators.len()
     }
 
+    pub fn me(&self) -> Participant {
+        self.me
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn generate_internal(
         participants: &Participants,
@@ -239,13 +243,18 @@ impl SignatureManager {
         ))
     }
 
+    pub fn take_failed_generator(&mut self) -> Option<(CryptoHash, FailedGenerator)> {
+        self.failed_generators.pop_front()
+    }
+
     pub fn retry_failed_generation(
         &mut self,
+        receipt_id: CryptoHash,
+        failed_generator: &FailedGenerator,
         presignature: Presignature,
         participants: &Participants,
     ) -> Option<()> {
-        let (hash, failed_generator) = self.failed_generators.pop_front()?;
-        tracing::info!(receipt_id = %hash, participants = ?participants.keys().collect::<Vec<_>>(), "restarting failed protocol to generate signature");
+        tracing::info!(receipt_id = %receipt_id, participants = ?participants.keys().collect::<Vec<_>>(), "restarting failed protocol to generate signature");
         let generator = Self::generate_internal(
             participants,
             self.me,
@@ -258,7 +267,7 @@ impl SignatureManager {
             failed_generator.sign_request_timestamp,
         )
         .unwrap();
-        self.generators.insert(hash, generator);
+        self.generators.insert(receipt_id, generator);
         Some(())
     }
 


### PR DESCRIPTION
check if the failed generator's proposer == me, only take my presignature and retry if it's true.