### PR TITLE
Lowered the minimum gas limit and upped the depth

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -9,7 +9,7 @@ use primitives::ParticipantInfo;
 use primitives::{CandidateInfo, Candidates, Participants, PkVotes, Votes};
 use std::collections::{BTreeMap, HashSet};
 
-const GAS_FOR_SIGN_CALL: Gas = Gas::from_gas(3 * 100_000_000_000_000);
+const GAS_FOR_SIGN_CALL: Gas = Gas::from_gas(250_000_000_000_000);
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug)]
 pub struct InitializingContractState {
@@ -387,7 +387,7 @@ impl MpcContract {
                     // Make sure we have enough gas left to do 1 more call and clean up afterwards
                     // Observationally 30 calls < 300 TGas so 2 calls < 20 TGas
                     // We keep one call back so we can cleanup then call panic on the next call
-                    if depth > 29 {
+                    if depth > 30 {
                         self.remove_request(&payload);
                         let self_id = env::current_account_id();
                         PromiseOrValue::Promise(Self::ext(self_id).fail_helper(

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -9,7 +9,7 @@ use primitives::ParticipantInfo;
 use primitives::{CandidateInfo, Candidates, Participants, PkVotes, Votes};
 use std::collections::{BTreeMap, HashSet};
 
-const GAS_FOR_SIGN_CALL: Gas = Gas::from_gas(250_000_000_000_000);
+const GAS_FOR_SIGN_CALL: Gas = Gas::from_tgas(250);
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug)]
 pub struct InitializingContractState {

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -387,7 +387,8 @@ impl MpcContract {
                     // Make sure we have enough gas left to do 1 more call and clean up afterwards
                     // Observationally 30 calls < 300 TGas so 2 calls < 20 TGas
                     // We keep one call back so we can cleanup then call panic on the next call
-                    if depth > 30 {
+                    // Start cleaning up if there's less than 25 teragas left regardless of how deep you are.
+                    if depth > 30 || env::prepaid_gas() < Gas::from_tgas(25) {
                         self.remove_request(&payload);
                         let self_id = env::current_account_id();
                         PromiseOrValue::Promise(Self::ext(self_id).fail_helper(


### PR DESCRIPTION
Observationally 30 transactions uses about 160 TG of Gas, so 250 should be plenty. The protocol team says that this should come down soon.

The current gas limit makes it impossible for people to call the sign method using another smart contract.

In the future we should abort when the remaining gas in the call starts to get low to avoid the risk of an out of gas panic causing the system to not clean up after itself.