### PR TITLE
fix: allow triple memory only

### DIFF
--- a/node/src/protocol/presignature.rs
+++ b/node/src/protocol/presignature.rs
@@ -362,8 +362,7 @@ impl PresignatureManager {
     pub fn take_mine(&mut self) -> Option<Presignature> {
         tracing::info!(mine = ?self.mine, "my presignatures");
         let my_presignature_id = self.mine.pop_front()?;
-        self.taken.insert(my_presignature_id, Instant::now());
-        Some(self.presignatures.remove(&my_presignature_id).unwrap())
+        self.take(my_presignature_id)
     }
 
     pub fn take(&mut self, id: PresignatureId) -> Option<Presignature> {

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -96,17 +96,8 @@ impl ReshareProtocol {
         me: Participant,
         contract_state: &ResharingContractState,
     ) -> Result<Self, InitializationError> {
-        let old_participants = contract_state
-            .old_participants
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>();
-
-        let new_participants = contract_state
-            .new_participants
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>();
+        let old_participants = contract_state.old_participants.keys_vec();
+        let new_participants = contract_state.new_participants.keys_vec();
 
         Ok(Self {
             protocol: Arc::new(RwLock::new(Box::new(cait_sith::reshare::<Secp256k1>(


### PR DESCRIPTION
This allows us to triples from memory only in the case the triples were never saved to datastore somehow and rely purely on local memory. This is good in the case that datastore service is down somehow