### PR TITLE
v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4046,7 +4046,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-contract"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh 1.3.1",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-recovery-node"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpc-contract"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpc-recovery-node"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
Let's tag what we have ATM as `v0.2.0` and move forward from it.
Let's merge this to develop, then `develop`->`main`, then do the release.