### PR TITLE
feat: compile time binary builds for integration tests

### DIFF
--- a/integration-tests/chain-signatures/Cargo.toml
+++ b/integration-tests/chain-signatures/Cargo.toml
@@ -56,6 +56,11 @@ ethers-core = "2.0.13"
 web3 = "0.19.0"
 secp256k1 = "0.28.2"
 
+[build-dependencies]
+anyhow = "1"
+async-process = "1"
+tokio = { version = "1", features = ["full"] }
+
 [workspace] # used to ignore higher level workspace
 
 [features]

--- a/integration-tests/chain-signatures/build.rs
+++ b/integration-tests/chain-signatures/build.rs
@@ -1,3 +1,98 @@
-// HACK: need this build script so that env var OUT_DIR gets set:
-// https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
-fn main() {}
+use std::path::Path;
+use std::{env, io};
+
+use anyhow::Context;
+use async_process::{Command, ExitStatus, Stdio};
+
+const PACKAGE_MULTICHAIN: &str = "mpc-recovery-node";
+const PACKAGE_CONTRACT: &str = "mpc-contract";
+const TARGET_CONTRACT: &str = "wasm32-unknown-unknown";
+const TARGET_FOLDER: &str = "target";
+
+fn target_dir() -> io::Result<std::path::PathBuf> {
+    let out_dir = env::var("OUT_DIR").map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("could not find OUT_DIR environment variable: {err:?}"),
+        )
+    })?;
+    let mut out_dir = Path::new(&out_dir);
+    loop {
+        if out_dir.ends_with(TARGET_FOLDER) {
+            break Ok(out_dir.to_path_buf());
+        }
+
+        match out_dir.parent() {
+            Some(parent) => out_dir = parent,
+            // We've reached the root directory and didn't find "target"
+            None => {
+                break Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "could not find /target",
+                ))
+            }
+        }
+    }
+}
+
+async fn build_package(
+    release: bool,
+    package: &str,
+    target: Option<&str>,
+    target_dir: Option<impl AsRef<Path>>,
+) -> anyhow::Result<ExitStatus> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build")
+        .arg("--package")
+        .arg(package)
+        .envs(env::vars())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    if release {
+        cmd.arg("--release");
+    }
+
+    if let Some(target) = target {
+        cmd.arg("--target").arg(target);
+    }
+
+    if let Some(target_dir) = target_dir {
+        cmd.arg("--target-dir").arg(target_dir.as_ref().as_os_str());
+    }
+
+    Ok(cmd.spawn()?.status().await?)
+}
+
+async fn build_multichain(release: bool) -> anyhow::Result<ExitStatus> {
+    let target_dir = target_dir().context("could not find /target while building node")?;
+    build_package(release, PACKAGE_MULTICHAIN, None, Some(target_dir)).await
+}
+
+async fn build_multichain_contract(release: bool) -> anyhow::Result<ExitStatus> {
+    let target_dir = target_dir().context("could not find /target while building contract")?;
+    // We use a different target directory to stop the different rustflags between targets from clobbering the build cache
+    build_package(
+        release,
+        PACKAGE_CONTRACT,
+        Some(TARGET_CONTRACT),
+        Some(target_dir),
+    )
+    .await
+}
+
+fn main() -> anyhow::Result<()> {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=../../contract/");
+    println!("cargo:rerun-if-changed=../../keys/");
+    println!("cargo:rerun-if-changed=../../node/");
+
+    let release = true;
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        build_multichain_contract(release).await?;
+        build_multichain(release).await?;
+
+        Ok(())
+    })
+}

--- a/integration-tests/chain-signatures/src/lib.rs
+++ b/integration-tests/chain-signatures/src/lib.rs
@@ -230,15 +230,7 @@ pub struct Context<'a> {
 }
 
 pub async fn setup(docker_client: &DockerClient) -> anyhow::Result<Context<'_>> {
-    if !execute::build_multichain_contract().await?.success() {
-        anyhow::bail!("failed to prebuild multichain contract");
-    }
-
     let release = true;
-    if !execute::build_multichain(release).await?.success() {
-        anyhow::bail!("failed to prebuild multichain node service");
-    }
-
     let docker_network = NETWORK;
     docker_client.create_network(docker_network).await?;
 

--- a/integration-tests/fastauth/Cargo.toml
+++ b/integration-tests/fastauth/Cargo.toml
@@ -41,6 +41,11 @@ mpc-recovery = { path = "../../mpc-recovery" }
 [dev-dependencies]
 test-log = { version = "0.2.12", features = ["log", "trace"] }
 
+[build-dependencies]
+anyhow = "1"
+async-process = "1"
+tokio = { version = "1", features = ["full"] }
+
 
 [workspace] # used to ignore higher level workspace
 

--- a/integration-tests/fastauth/build.rs
+++ b/integration-tests/fastauth/build.rs
@@ -1,3 +1,82 @@
-// HACK: need this build script so that env var OUT_DIR gets set:
-// https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
-fn main() {}
+use std::path::Path;
+use std::{env, io};
+
+use anyhow::Context;
+use async_process::{Command, ExitStatus, Stdio};
+
+const PACKAGE: &str = "mpc-recovery";
+const TARGET_FOLDER: &str = "target";
+
+fn target_dir() -> io::Result<std::path::PathBuf> {
+    let out_dir = env::var("OUT_DIR").map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("could not find OUT_DIR environment variable: {err:?}"),
+        )
+    })?;
+    let mut out_dir = Path::new(&out_dir);
+    loop {
+        if out_dir.ends_with(TARGET_FOLDER) {
+            break Ok(out_dir.to_path_buf());
+        }
+
+        match out_dir.parent() {
+            Some(parent) => out_dir = parent,
+            // We've reached the root directory and didn't find "target"
+            None => {
+                break Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "could not find /target",
+                ))
+            }
+        }
+    }
+}
+
+async fn build_package(
+    release: bool,
+    package: &str,
+    target_dir: Option<impl AsRef<Path>>,
+) -> anyhow::Result<ExitStatus> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build")
+        .arg("--package")
+        .arg(package)
+        .envs(std::env::vars())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    if release {
+        cmd.arg("--release");
+    }
+
+    if let Some(target_dir) = target_dir {
+        cmd.arg("--target-dir").arg(target_dir.as_ref().as_os_str());
+    }
+
+    Ok(cmd.spawn()?.status().await?)
+}
+
+pub async fn build_mpc(release: bool) -> anyhow::Result<ExitStatus> {
+    build_package(
+        release,
+        PACKAGE,
+        Some(target_dir().context("could not find /target while building mpc-recovery")?),
+    )
+    .await
+}
+
+fn main() -> anyhow::Result<()> {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=../../mpc-recovery/");
+
+    #[cfg(not(feature = "flamegraph"))]
+    {
+        let release = true;
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            build_mpc(release).await?;
+            Ok(())
+        })
+    }
+}

--- a/integration-tests/fastauth/src/env/mod.rs
+++ b/integration-tests/fastauth/src/env/mod.rs
@@ -102,11 +102,6 @@ pub struct Context<'a> {
 
 pub async fn setup(docker_client: &DockerClient) -> anyhow::Result<Context<'_>> {
     let release = true;
-    #[cfg(not(feature = "flamegraph"))]
-    if !crate::mpc::build(release).await?.success() {
-        anyhow::bail!("failed to prebuild MPC service");
-    }
-
     let gcp_project_id = GCP_PROJECT_ID;
     let docker_network = NETWORK;
     docker_client.create_network(docker_network).await?;


### PR DESCRIPTION
Offload all binary builds to compile time. Integration tests now will only build binaries during compile time and not during test/runtime