### PR TITLE
fix: clear triples after reshare

### DIFF
--- a/.github/workflows/multichain-integration.yml
+++ b/.github/workflows/multichain-integration.yml
@@ -84,5 +84,5 @@ jobs:
         working-directory: ./integration-tests/chain-signatures
         run: cargo test --jobs 1 -- --test-threads 1
         env:
-          RUST_LOG: INFO
+          RUST_LOG: info,workspaces=warn
           RUST_BACKTRACE: 1

--- a/chain-signatures/node/src/gcp/mod.rs
+++ b/chain-signatures/node/src/gcp/mod.rs
@@ -280,11 +280,9 @@ impl DatastoreService {
             )
         })?;
 
-        batch.entity_results.ok_or_else(|| {
-            DatastoreStorageError::FetchEntitiesError(
-                "Could not retrieve entity results while fetching entities".to_string(),
-            )
-        })
+        // NOTE: if entity_results is None, we return an empty Vec since the fetch query
+        // could not find any entities in the DB.
+        Ok(batch.entity_results.unwrap_or_default())
     }
 
     #[tracing::instrument(level = "debug", skip_all)]

--- a/chain-signatures/node/src/protocol/message.rs
+++ b/chain-signatures/node/src/protocol/message.rs
@@ -298,8 +298,14 @@ impl MessageHandler for RunningState {
                         leftover_messages.push(message)
                     }
                     Err(presignature::GenerationError::TripleIsMissing(_)) => {
-                        // Store the message until triple is ready
-                        leftover_messages.push(message)
+                        // If a triple is missing, that means our system cannot process this presignature. We will have to bin
+                        // this message and have the other node timeout on that generation.
+                        tracing::warn!(
+                            presignature_id = id,
+                            triple0 = message.triple0,
+                            triple1 = message.triple1,
+                            "unable to process presignature: one or more triples are missing",
+                        );
                     }
                     Err(presignature::GenerationError::CaitSithInitializationError(error)) => {
                         // ignore the message since the generation had bad parameters. Also have the other node who

--- a/chain-signatures/node/src/protocol/message.rs
+++ b/chain-signatures/node/src/protocol/message.rs
@@ -311,10 +311,6 @@ impl MessageHandler for RunningState {
                         );
                         continue;
                     }
-                    Err(presignature::GenerationError::DatastoreStorageError(_)) => {
-                        // Store the message until we are ready to process it
-                        leftover_messages.push(message)
-                    }
                 }
             }
             if !leftover_messages.is_empty() {

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -87,8 +87,6 @@ pub enum GenerationError {
     TripleIsMissing(TripleId),
     #[error("cait-sith initialization error: {0}")]
     CaitSithInitializationError(#[from] InitializationError),
-    #[error("datastore storage error: {0}")]
-    DatastoreStorageError(#[from] DatastoreStorageError),
     #[error("triple {0} is generating")]
     TripleIsGenerating(TripleId),
 }

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -1,6 +1,5 @@
 use super::message::PresignatureMessage;
 use super::triple::{Triple, TripleConfig, TripleId, TripleManager};
-use crate::gcp::error::DatastoreStorageError;
 use crate::protocol::contract::primitives::Participants;
 use crate::types::{PresignatureProtocol, SecretKeyShare};
 use crate::util::AffinePointExt;


### PR DESCRIPTION
We were not clearing our triples from datastore after a reshare, which is required due to there being new participants and potentially older ones no longer existing. The old set of triples would for the most part not be valid and should just cleared. We were already clearing them from memory when we construct a new `TripleManager`.

Also bins message on `TripleIsMissing` since that's the case where the node does not have the triple at all due to datastore corruption or was never observed in the system. We won't be able to go into a state where the triple is found so just delete the message.

This can be made more clear with a partitioning of where triples are stored https://github.com/near/transfer/issues/30. Which would allow us to serve signatures beyond the resharing phase if we'd like not to clear triples and maintain a separate network for a bit