### PR TITLE
reduce downtime: use newest instead of oldest triple and presig

### DIFF
--- a/chain-signatures/Cargo.lock
+++ b/chain-signatures/Cargo.lock
@@ -1753,6 +1753,7 @@ dependencies = [
  "near-sdk",
  "serde",
  "serde_json",
+ "sha3",
  "subtle",
 ]
 

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -398,7 +398,7 @@ impl PresignatureManager {
 
     pub fn take_mine(&mut self) -> Option<Presignature> {
         tracing::info!(mine = ?self.mine, "my presignatures");
-        let my_presignature_id = self.mine.pop_front()?;
+        let my_presignature_id = self.mine.pop_back()?;
         // SAFETY: This unwrap is safe because taking mine will always succeed since it is only
         // present when generation completes where the determination of ownership is made.
         Some(self.take(my_presignature_id).unwrap())

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -341,8 +341,8 @@ impl TripleManager {
         if self.mine.len() < 2 {
             return None;
         }
-        let id0 = self.mine.pop_front()?;
-        let id1 = self.mine.pop_front()?;
+        let id0 = self.mine.pop_back()?;
+        let id1 = self.mine.pop_back()?;
         tracing::info!(id0, id1, me = ?self.me, "trying to take two triples");
 
         let take_two_result = self.take_two(id0, id1).await;
@@ -359,8 +359,8 @@ impl TripleManager {
                     ?error,
                     "unable to take two triples: one or both of the triples are missing/not-generated",
                 );
-                self.mine.push_front(id1);
-                self.mine.push_front(id0);
+                self.mine.push_back(id1);
+                self.mine.push_back(id0);
                 None
             }
             Err(error) => {


### PR DESCRIPTION
Now when we need to generate presig, we take oldest triples first; when generating signature, we take oldest presig first. However when some nodes restart with no presig and other nodes keep popping old presig, all signature requests will time out until all the old presigs are exhausted. So it's better to start with newer presigs, so as more presig get generated, signature requests will be served in time.