### PR TITLE
use tokio::time::timeout to timeout fetch state and send encrypted

### DIFF
--- a/chain-signatures/contract/src/config/impls.rs
+++ b/chain-signatures/contract/src/config/impls.rs
@@ -57,7 +57,7 @@ impl Default for PresignatureConfig {
         Self {
             min_presignatures: 512,
             max_presignatures: 512 * MAX_EXPECTED_PARTICIPANTS * NETWORK_MULTIPLIER,
-            generation_timeout: secs_to_ms(45),
+            generation_timeout: secs_to_ms(90),
 
             other: Default::default(),
         }

--- a/chain-signatures/contract/src/config/impls.rs
+++ b/chain-signatures/contract/src/config/impls.rs
@@ -57,7 +57,7 @@ impl Default for PresignatureConfig {
         Self {
             min_presignatures: 512,
             max_presignatures: 512 * MAX_EXPECTED_PARTICIPANTS * NETWORK_MULTIPLIER,
-            generation_timeout: secs_to_ms(90),
+            generation_timeout: secs_to_ms(45),
 
             other: Default::default(),
         }

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -2,7 +2,7 @@ use crate::config::{Config, LocalConfig, NetworkConfig, OverrideConfig};
 use crate::gcp::GcpService;
 use crate::protocol::{MpcSignProtocol, SignQueue};
 use crate::storage::triple_storage::LockTripleNodeStorageBox;
-use crate::{indexer, storage, web};
+use crate::{http_client, indexer, mesh, storage, web};
 use clap::Parser;
 use local_ip_address::local_ip;
 use near_account_id::AccountId;
@@ -63,6 +63,10 @@ pub enum Cli {
         /// referer header for mainnet whitelist
         #[arg(long, env("MPC_CLIENT_HEADER_REFERER"), default_value(None))]
         client_header_referer: Option<String>,
+        #[clap(flatten)]
+        mesh_options: mesh::Options,
+        #[clap(flatten)]
+        message_options: http_client::Options,
     },
 }
 
@@ -83,6 +87,8 @@ impl Cli {
                 storage_options,
                 override_config,
                 client_header_referer,
+                mesh_options,
+                message_options,
             } => {
                 let mut args = vec![
                     "start".to_string(),
@@ -120,6 +126,8 @@ impl Cli {
 
                 args.extend(indexer_options.into_str_args());
                 args.extend(storage_options.into_str_args());
+                args.extend(mesh_options.into_str_args());
+                args.extend(message_options.into_str_args());
                 args
             }
         }
@@ -176,6 +184,8 @@ pub fn run(cmd: Cli) -> anyhow::Result<()> {
             storage_options,
             override_config,
             client_header_referer,
+            mesh_options,
+            message_options,
         } => {
             let sign_queue = Arc::new(RwLock::new(SignQueue::new()));
             let rt = tokio::runtime::Builder::new_multi_thread()
@@ -237,6 +247,8 @@ pub fn run(cmd: Cli) -> anyhow::Result<()> {
                         sign_sk,
                     },
                 }),
+                mesh_options,
+                message_options,
             );
 
             rt.block_on(async {

--- a/chain-signatures/node/src/http_client.rs
+++ b/chain-signatures/node/src/http_client.rs
@@ -56,23 +56,6 @@ async fn send_encrypted<U: IntoUrl>(
     url.set_path("msg");
     tracing::debug!(?from, to = %url, "making http request: sending encrypted message");
     let action = || async {
-<<<<<<< HEAD
-        let response = client
-            .post(url.clone())
-            .header("content-type", "application/json")
-            .json(&message)
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-            .timeout(Duration::from_millis(400))
->>>>>>> b340f1a0 (increase timeout)
-=======
-            .timeout(Duration::from_millis(200))
->>>>>>> 26a2f6a4 (revert timeout, change presig timeout)
-            .send()
-            .await
-            .map_err(SendError::ReqwestClientError)?;
-=======
         let response = tokio::time::timeout(
             request_timeout,
             client
@@ -85,7 +68,6 @@ async fn send_encrypted<U: IntoUrl>(
         .map_err(|_| SendError::Timeout(format!("send encrypted from {from:?} to {url}")))?
         .map_err(SendError::ReqwestClientError)?;
 
->>>>>>> 611df5c0 (refactor: all param in env variables)
         let status = response.status();
         let response_bytes = response
             .bytes()

--- a/chain-signatures/node/src/http_client.rs
+++ b/chain-signatures/node/src/http_client.rs
@@ -47,9 +47,13 @@ async fn send_encrypted<U: IntoUrl>(
             .header("content-type", "application/json")
             .json(&message)
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
             .timeout(Duration::from_millis(400))
 >>>>>>> b340f1a0 (increase timeout)
+=======
+            .timeout(Duration::from_millis(200))
+>>>>>>> 26a2f6a4 (revert timeout, change presig timeout)
             .send()
             .await
             .map_err(SendError::ReqwestClientError)?;

--- a/chain-signatures/node/src/http_client.rs
+++ b/chain-signatures/node/src/http_client.rs
@@ -46,6 +46,10 @@ async fn send_encrypted<U: IntoUrl>(
             .post(url.clone())
             .header("content-type", "application/json")
             .json(&message)
+<<<<<<< HEAD
+=======
+            .timeout(Duration::from_millis(400))
+>>>>>>> b340f1a0 (increase timeout)
             .send()
             .await
             .map_err(SendError::ReqwestClientError)?;

--- a/chain-signatures/node/src/http_client.rs
+++ b/chain-signatures/node/src/http_client.rs
@@ -11,6 +11,19 @@ use std::time::{Duration, Instant};
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;
 
+#[derive(Debug, Clone, clap::Parser)]
+#[group(id = "message_options")]
+pub struct Options {
+    #[clap(long, env("MPC_MESSAGE_TIMEOUT"), default_value = "1000")]
+    pub timeout: u64,
+}
+
+impl Options {
+    pub fn into_str_args(self) -> Vec<String> {
+        vec!["--timeout".to_string(), self.timeout.to_string()]
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum SendError {
     #[error("http request was unsuccessful: {0}")]
@@ -36,12 +49,14 @@ async fn send_encrypted<U: IntoUrl>(
     client: &Client,
     url: U,
     message: Vec<Ciphered>,
+    request_timeout: Duration,
 ) -> Result<(), SendError> {
     let _span = tracing::info_span!("message_request");
     let mut url = url.into_url()?;
     url.set_path("msg");
     tracing::debug!(?from, to = %url, "making http request: sending encrypted message");
     let action = || async {
+<<<<<<< HEAD
         let response = client
             .post(url.clone())
             .header("content-type", "application/json")
@@ -57,6 +72,20 @@ async fn send_encrypted<U: IntoUrl>(
             .send()
             .await
             .map_err(SendError::ReqwestClientError)?;
+=======
+        let response = tokio::time::timeout(
+            request_timeout,
+            client
+                .post(url.clone())
+                .header("content-type", "application/json")
+                .json(&message)
+                .send(),
+        )
+        .await
+        .map_err(|_| SendError::Timeout(format!("send encrypted from {from:?} to {url}")))?
+        .map_err(SendError::ReqwestClientError)?;
+
+>>>>>>> 611df5c0 (refactor: all param in env variables)
         let status = response.status();
         let response_bytes = response
             .bytes()
@@ -83,13 +112,21 @@ async fn send_encrypted<U: IntoUrl>(
 
 // TODO: add in retry logic either in struct or at call site.
 // TODO: add check for participant list to see if the messages to be sent are still valid.
-#[derive(Default)]
 pub struct MessageQueue {
     deque: VecDeque<(ParticipantInfo, MpcMessage, Instant)>,
     seen_counts: HashSet<String>,
+    message_options: Options,
 }
 
 impl MessageQueue {
+    pub fn new(options: Options) -> Self {
+        Self {
+            deque: VecDeque::default(),
+            seen_counts: HashSet::default(),
+            message_options: options,
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.deque.len()
     }
@@ -155,7 +192,14 @@ impl MessageQueue {
                 crate::metrics::NUM_SEND_ENCRYPTED_TOTAL
                     .with_label_values(&[account_id.as_str()])
                     .inc();
-                if let Err(err) = send_encrypted(from, client, &info.url, encrypted_partition).await
+                if let Err(err) = send_encrypted(
+                    from,
+                    client,
+                    &info.url,
+                    encrypted_partition,
+                    Duration::from_millis(self.message_options.timeout),
+                )
+                .await
                 {
                     crate::metrics::NUM_SEND_ENCRYPTED_FAILURE
                         .with_label_values(&[account_id.as_str()])

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -50,7 +50,7 @@ impl Pool {
             };
 
             let work = self.http.get(url.clone()).send();
-            match tokio::time::timeout(Duration::from_millis(200), work).await {
+            match tokio::time::timeout(Duration::from_millis(500), work).await {
                 Ok(result) => match result {
                     Ok(resp) => {
                         let Ok(state): Result<StateView, _> = resp.json().await else {

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -50,7 +50,7 @@ impl Pool {
             };
 
             let work = self.http.get(url.clone()).send();
-            match tokio::time::timeout(Duration::from_millis(500), work).await {
+            match tokio::time::timeout(Duration::from_millis(1000), work).await {
                 Ok(result) => match result {
                     Ok(resp) => {
                         let Ok(state): Result<StateView, _> = resp.json().await else {

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -50,7 +50,7 @@ impl Pool {
             };
 
             let work = self.http.get(url.clone()).send();
-            match tokio::time::timeout(Duration::from_millis(1000), work).await {
+            match tokio::time::timeout(Duration::from_millis(5000), work).await {
                 Ok(result) => match result {
                     Ok(resp) => {
                         let Ok(state): Result<StateView, _> = resp.json().await else {

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -6,10 +6,9 @@ use tokio::sync::RwLock;
 use url::Url;
 
 use crate::protocol::contract::primitives::Participants;
+use crate::protocol::ParticipantInfo;
 use crate::protocol::ProtocolState;
 use crate::web::StateView;
-
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(1);
 
 // TODO: this is a basic connection pool and does not do most of the work yet. This is
 //       mostly here just to facilitate offline node handling for now.
@@ -25,12 +24,43 @@ pub struct Pool {
     current_active: RwLock<Option<(Participants, Instant)>>,
     // Potentially active participants that we can use to establish a connection in the next epoch.
     potential_active: RwLock<Option<(Participants, Instant)>>,
+    fetch_participant_timeout: Duration,
+    refresh_active_timeout: Duration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum FetchParticipantError {
+    #[error("request timed out")]
+    Timeout,
+    #[error("Response cannot be converted to JSON")]
+    JsonConversion,
+    #[error("Invalid URL")]
+    InvalidUrl,
+    #[error("Network error: {0}")]
+    NetworkError(String),
 }
 
 impl Pool {
+    pub fn new(fetch_participant_timeout: Duration, refresh_active_timeout: Duration) -> Self {
+        tracing::info!(
+            ?fetch_participant_timeout,
+            ?refresh_active_timeout,
+            "creating a new pool"
+        );
+        Self {
+            http: reqwest::Client::new(),
+            connections: RwLock::new(Participants::default()),
+            potential_connections: RwLock::new(Participants::default()),
+            status: RwLock::new(HashMap::default()),
+            current_active: RwLock::new(Option::default()),
+            potential_active: RwLock::new(Option::default()),
+            fetch_participant_timeout,
+            refresh_active_timeout,
+        }
+    }
     pub async fn ping(&self) -> Participants {
         if let Some((ref active, timestamp)) = *self.current_active.read().await {
-            if timestamp.elapsed() < DEFAULT_TIMEOUT {
+            if timestamp.elapsed() < self.refresh_active_timeout {
                 return active.clone();
             }
         }
@@ -40,46 +70,15 @@ impl Pool {
         let mut status = self.status.write().await;
         let mut participants = Participants::default();
         for (participant, info) in connections.iter() {
-            let Ok(Ok(url)) = Url::parse(&info.url).map(|url| url.join("/state")) else {
-                tracing::error!(
-                    "Pool.ping url is invalid participant {:?} url {} /state",
-                    participant,
-                    info.url
-                );
-                continue;
-            };
-
-            let work = self.http.get(url.clone()).send();
-            match tokio::time::timeout(Duration::from_millis(1000), work).await {
-                Ok(result) => match result {
-                    Ok(resp) => {
-                        let Ok(state): Result<StateView, _> = resp.json().await else {
-                            tracing::warn!(
-                                "Pool.ping state view err participant {:?} url {}",
-                                participant,
-                                url
-                            );
-                            continue;
-                        };
-            
-                        status.insert(*participant, state);
-                        participants.insert(participant, info.clone());
-                    },
-                    Err(e) => {
-                        tracing::warn!("Network error: {:?}", e);
-                        continue;
-                    }
-                },
-                Err(_) => {
-                    tracing::warn!(
-                        "Pool.ping resp err participant {:?} url {}, timed out",
-                        participant,
-                        url
-                    );
-                    continue;
+            match self.fetch_participant_state(info).await {
+                Ok(state) => {
+                    status.insert(*participant, state);
+                    participants.insert(participant, info.clone());
                 }
-            };
-            
+                Err(e) => {
+                    tracing::warn!("Fetch state for participant {participant:?} with url {} has failed with error {e}.", info.url);
+                }
+            }
         }
         drop(status);
 
@@ -90,7 +89,7 @@ impl Pool {
 
     pub async fn ping_potential(&self) -> Participants {
         if let Some((ref active, timestamp)) = *self.potential_active.read().await {
-            if timestamp.elapsed() < DEFAULT_TIMEOUT {
+            if timestamp.elapsed() < self.refresh_active_timeout {
                 return active.clone();
             }
         }
@@ -100,20 +99,15 @@ impl Pool {
         let mut status = self.status.write().await;
         let mut participants = Participants::default();
         for (participant, info) in connections.iter() {
-            let Ok(Ok(url)) = Url::parse(&info.url).map(|url| url.join("/state")) else {
-                continue;
-            };
-
-            let Ok(resp) = self.http.get(url).send().await else {
-                continue;
-            };
-
-            let Ok(state): Result<StateView, _> = resp.json().await else {
-                continue;
-            };
-
-            status.insert(*participant, state);
-            participants.insert(participant, info.clone());
+            match self.fetch_participant_state(info).await {
+                Ok(state) => {
+                    status.insert(*participant, state);
+                    participants.insert(participant, info.clone());
+                }
+                Err(e) => {
+                    tracing::warn!("Fetch state for participant {participant:?} with url {} has failed with error {e}.", info.url);
+                }
+            }
         }
         drop(status);
 
@@ -169,5 +163,27 @@ impl Pool {
                 StateView::Running { is_stable, .. } => *is_stable,
                 _ => false,
             })
+    }
+
+    async fn fetch_participant_state(
+        &self,
+        participant_info: &ParticipantInfo,
+    ) -> Result<StateView, FetchParticipantError> {
+        let Ok(Ok(url)) = Url::parse(&participant_info.url).map(|url| url.join("/state")) else {
+            return Err(FetchParticipantError::InvalidUrl);
+        };
+        match tokio::time::timeout(
+            self.fetch_participant_timeout,
+            self.http.get(url.clone()).send(),
+        )
+        .await
+        {
+            Ok(Ok(resp)) => match resp.json::<StateView>().await {
+                Ok(state) => Ok(state),
+                Err(_) => Err(FetchParticipantError::JsonConversion),
+            },
+            Ok(Err(e)) => Err(FetchParticipantError::NetworkError(e.to_string())),
+            Err(_) => Err(FetchParticipantError::Timeout),
+        }
     }
 }

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -50,7 +50,7 @@ impl Pool {
             };
 
             let work = self.http.get(url.clone()).send();
-            match tokio::time::timeout(Duration::from_millis(5000), work).await {
+            match tokio::time::timeout(Duration::from_millis(1000), work).await {
                 Ok(result) => match result {
                     Ok(resp) => {
                         let Ok(state): Result<StateView, _> = resp.json().await else {

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -23,6 +23,8 @@ use self::consensus::ConsensusCtx;
 use self::cryptography::CryptographicCtx;
 use self::message::MessageCtx;
 use crate::config::Config;
+use crate::http_client;
+use crate::mesh;
 use crate::mesh::Mesh;
 use crate::protocol::consensus::ConsensusProtocol;
 use crate::protocol::cryptography::CryptographicProtocol;
@@ -54,6 +56,7 @@ struct Ctx {
     triple_storage: LockTripleNodeStorageBox,
     cfg: Config,
     mesh: Mesh,
+    message_options: http_client::Options,
 }
 
 impl ConsensusCtx for &mut MpcSignProtocol {
@@ -95,6 +98,10 @@ impl ConsensusCtx for &mut MpcSignProtocol {
 
     fn triple_storage(&self) -> LockTripleNodeStorageBox {
         self.ctx.triple_storage.clone()
+    }
+
+    fn message_options(&self) -> http_client::Options {
+        self.ctx.message_options.clone()
     }
 }
 
@@ -167,6 +174,8 @@ impl MpcSignProtocol {
         secret_storage: SecretNodeStorageBox,
         triple_storage: LockTripleNodeStorageBox,
         cfg: Config,
+        mesh_options: mesh::Options,
+        message_options: http_client::Options,
     ) -> (Self, Arc<RwLock<NodeState>>) {
         let my_address = my_address.into_url().unwrap();
         let rpc_url = rpc_client.rpc_addr();
@@ -192,7 +201,8 @@ impl MpcSignProtocol {
             secret_storage,
             triple_storage,
             cfg,
-            mesh: Mesh::default(),
+            mesh: Mesh::new(mesh_options),
+            message_options,
         };
         let protocol = MpcSignProtocol {
             ctx,

--- a/integration-tests/chain-signatures/src/containers.rs
+++ b/integration-tests/chain-signatures/src/containers.rs
@@ -117,6 +117,8 @@ impl<'a> Node<'a> {
                 config.cfg.protocol.clone(),
             )?)),
             client_header_referer: None,
+            mesh_options: ctx.mesh_options.clone(),
+            message_options: ctx.message_options.clone(),
         }
         .into_str_args();
         let image: GenericImage = GenericImage::new("near/mpc-node", "latest")

--- a/integration-tests/chain-signatures/src/lib.rs
+++ b/integration-tests/chain-signatures/src/lib.rs
@@ -15,6 +15,8 @@ use futures::StreamExt;
 use mpc_contract::config::{PresignatureConfig, ProtocolConfig, TripleConfig};
 use mpc_contract::primitives::CandidateInfo;
 use mpc_node::gcp::GcpService;
+use mpc_node::http_client;
+use mpc_node::mesh;
 use mpc_node::storage;
 use mpc_node::storage::triple_storage::TripleNodeStorageBox;
 use near_crypto::KeyFile;
@@ -206,6 +208,8 @@ pub struct Context<'a> {
     pub mpc_contract: Contract,
     pub datastore: crate::containers::Datastore<'a>,
     pub storage_options: storage::Options,
+    pub mesh_options: mesh::Options,
+    pub message_options: http_client::Options,
 }
 
 pub async fn setup(docker_client: &DockerClient) -> anyhow::Result<Context<'_>> {
@@ -240,6 +244,14 @@ pub async fn setup(docker_client: &DockerClient) -> anyhow::Result<Context<'_>> 
         gcp_datastore_url: Some(datastore.local_address.clone()),
         sk_share_local_path: Some(sk_share_local_path),
     };
+
+    let mesh_options = mpc_node::mesh::Options {
+        fetch_participant_timeout: 1000,
+        refresh_active_timeout: 1000,
+    };
+
+    let message_options = http_client::Options { timeout: 1000 };
+
     Ok(Context {
         docker_client,
         docker_network: docker_network.to_string(),
@@ -250,6 +262,8 @@ pub async fn setup(docker_client: &DockerClient) -> anyhow::Result<Context<'_>> 
         mpc_contract,
         datastore,
         storage_options,
+        mesh_options,
+        message_options,
     })
 }
 

--- a/integration-tests/chain-signatures/src/local.rs
+++ b/integration-tests/chain-signatures/src/local.rs
@@ -74,6 +74,8 @@ impl Node {
                 cfg.protocol.clone(),
             )?)),
             client_header_referer: None,
+            mesh_options: ctx.mesh_options.clone(),
+            message_options: ctx.message_options.clone(),
         };
 
         let cmd = executable(ctx.release, crate::execute::PACKAGE_MULTICHAIN)
@@ -165,6 +167,8 @@ impl Node {
                 config.cfg.protocol.clone(),
             )?)),
             client_header_referer: None,
+            mesh_options: ctx.mesh_options.clone(),
+            message_options: ctx.message_options.clone(),
         };
 
         let mpc_node_id = format!("multichain/{}", config.account.id());


### PR DESCRIPTION
The previous implementation caused troubles: 1) 1s timeout have already stuck the protocol; 2) 500ms timeout still see many timeouts on /state endpoint.
I am guessing the .timeout() that came with reqwest package cannot successfully time out an async call, the counting of time may not have considered task/thread switching.
So I switched to using tokio::time::timeout and now problem solved. 
Dev success increased from 70% to 100%.

This change sets the timeout to 1000ms for both fetch /state and for send encrypted. Both can be tuned as an environment variable.