### PR TITLE
add /msg to criteria of active participants

### DIFF
--- a/chain-signatures/contract/src/config/impls.rs
+++ b/chain-signatures/contract/src/config/impls.rs
@@ -57,7 +57,7 @@ impl Default for PresignatureConfig {
         Self {
             min_presignatures: 512,
             max_presignatures: 512 * MAX_EXPECTED_PARTICIPANTS * NETWORK_MULTIPLIER,
-            generation_timeout: secs_to_ms(45),
+            generation_timeout: secs_to_ms(90),
 
             other: Default::default(),
         }

--- a/chain-signatures/contract/src/config/impls.rs
+++ b/chain-signatures/contract/src/config/impls.rs
@@ -57,7 +57,7 @@ impl Default for PresignatureConfig {
         Self {
             min_presignatures: 512,
             max_presignatures: 512 * MAX_EXPECTED_PARTICIPANTS * NETWORK_MULTIPLIER,
-            generation_timeout: secs_to_ms(90),
+            generation_timeout: secs_to_ms(45),
 
             other: Default::default(),
         }

--- a/chain-signatures/node/src/http_client.rs
+++ b/chain-signatures/node/src/http_client.rs
@@ -44,7 +44,7 @@ pub enum SendError {
     ParticipantNotAlive(String),
 }
 
-async fn send_encrypted<U: IntoUrl>(
+pub async fn send_encrypted<U: IntoUrl>(
     from: Participant,
     client: &Client,
     url: U,

--- a/chain-signatures/node/src/http_client.rs
+++ b/chain-signatures/node/src/http_client.rs
@@ -56,7 +56,6 @@ async fn send_encrypted<U: IntoUrl>(
     url.set_path("msg");
     tracing::debug!(?from, to = %url, "making http request: sending encrypted message");
     let action = || async {
-<<<<<<< HEAD
         let response = tokio::time::timeout(
             request_timeout,
             client
@@ -69,16 +68,6 @@ async fn send_encrypted<U: IntoUrl>(
         .map_err(|_| SendError::Timeout(format!("send encrypted from {from:?} to {url}")))?
         .map_err(SendError::ReqwestClientError)?;
 
-=======
-        let response = client
-            .post(url.clone())
-            .header("content-type", "application/json")
-            .json(&message)
-            .timeout(Duration::from_millis(200))
-            .send()
-            .await
-            .map_err(SendError::ReqwestClientError)?;
->>>>>>> 26a2f6a4 (revert timeout, change presig timeout)
         let status = response.status();
         let response_bytes = response
             .bytes()

--- a/chain-signatures/node/src/http_client.rs
+++ b/chain-signatures/node/src/http_client.rs
@@ -56,6 +56,7 @@ async fn send_encrypted<U: IntoUrl>(
     url.set_path("msg");
     tracing::debug!(?from, to = %url, "making http request: sending encrypted message");
     let action = || async {
+<<<<<<< HEAD
         let response = tokio::time::timeout(
             request_timeout,
             client
@@ -68,6 +69,16 @@ async fn send_encrypted<U: IntoUrl>(
         .map_err(|_| SendError::Timeout(format!("send encrypted from {from:?} to {url}")))?
         .map_err(SendError::ReqwestClientError)?;
 
+=======
+        let response = client
+            .post(url.clone())
+            .header("content-type", "application/json")
+            .json(&message)
+            .timeout(Duration::from_millis(200))
+            .send()
+            .await
+            .map_err(SendError::ReqwestClientError)?;
+>>>>>>> 26a2f6a4 (revert timeout, change presig timeout)
         let status = response.status();
         let response_bytes = response
             .bytes()

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -9,6 +9,7 @@ use crate::protocol::contract::primitives::Participants;
 use crate::protocol::ParticipantInfo;
 use crate::protocol::ProtocolState;
 use crate::web::StateView;
+use mpc_keys::hpke::Ciphered;
 
 // TODO: this is a basic connection pool and does not do most of the work yet. This is
 //       mostly here just to facilitate offline node handling for now.
@@ -71,10 +72,15 @@ impl Pool {
         let mut participants = Participants::default();
         for (participant, info) in connections.iter() {
             match self.fetch_participant_state(info).await {
-                Ok(state) => {
-                    status.insert(*participant, state);
-                    participants.insert(participant, info.clone());
-                }
+                Ok(state) => match self.test_empty_msg(participant, info).await {
+                    Ok(()) => {
+                        status.insert(*participant, state);
+                        participants.insert(participant, info.clone());
+                    }
+                    Err(e) => {
+                        tracing::warn!("Send empty msg for participant {participant:?} with url {} has failed with error {e}.", info.url);
+                    }
+                },
                 Err(e) => {
                     tracing::warn!("Fetch state for participant {participant:?} with url {} has failed with error {e}.", info.url);
                 }
@@ -100,10 +106,15 @@ impl Pool {
         let mut participants = Participants::default();
         for (participant, info) in connections.iter() {
             match self.fetch_participant_state(info).await {
-                Ok(state) => {
-                    status.insert(*participant, state);
-                    participants.insert(participant, info.clone());
-                }
+                Ok(state) => match self.test_empty_msg(participant, info).await {
+                    Ok(()) => {
+                        status.insert(*participant, state);
+                        participants.insert(participant, info.clone());
+                    }
+                    Err(e) => {
+                        tracing::warn!("Send empty msg for participant {participant:?} with url {} has failed with error {e}.", info.url);
+                    }
+                },
                 Err(e) => {
                     tracing::warn!("Fetch state for participant {participant:?} with url {} has failed with error {e}.", info.url);
                 }
@@ -185,5 +196,21 @@ impl Pool {
             Ok(Err(e)) => Err(FetchParticipantError::NetworkError(e.to_string())),
             Err(_) => Err(FetchParticipantError::Timeout),
         }
+    }
+
+    async fn test_empty_msg(
+        &self,
+        participant: &Participant,
+        participant_info: &ParticipantInfo,
+    ) -> Result<(), crate::http_client::SendError> {
+        let empty_msg: Vec<Ciphered> = Vec::new();
+        crate::http_client::send_encrypted(
+            *participant,
+            &self.http,
+            participant_info.url.clone(),
+            empty_msg,
+            self.fetch_participant_timeout,
+        )
+        .await
     }
 }

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -70,7 +70,6 @@ impl Pool {
         let mut status = self.status.write().await;
         let mut participants = Participants::default();
         for (participant, info) in connections.iter() {
-<<<<<<< HEAD
             match self.fetch_participant_state(info).await {
                 Ok(state) => {
                     status.insert(*participant, state);
@@ -80,43 +79,6 @@ impl Pool {
                     tracing::warn!("Fetch state for participant {participant:?} with url {} has failed with error {e}.", info.url);
                 }
             }
-=======
-            let Ok(Ok(url)) = Url::parse(&info.url).map(|url| url.join("/state")) else {
-                tracing::error!(
-                    "Pool.ping url is invalid participant {:?} url {} /state",
-                    participant,
-                    info.url
-                );
-                continue;
-            };
-
-            let Ok(resp) = self
-                .http
-                .get(url.clone())
-                .timeout(Duration::from_millis(400))
-                .send()
-                .await
-            else {
-                tracing::warn!(
-                    "Pool.ping resp err participant {:?} url {}",
-                    participant,
-                    url
-                );
-                continue;
-            };
-
-            let Ok(state): Result<StateView, _> = resp.json().await else {
-                tracing::warn!(
-                    "Pool.ping state view err participant {:?} url {}",
-                    participant,
-                    url
-                );
-                continue;
-            };
-
-            status.insert(*participant, state);
-            participants.insert(participant, info.clone());
->>>>>>> b340f1a0 (increase timeout)
         }
         drop(status);
 

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -72,7 +72,7 @@ impl Pool {
         let mut participants = Participants::default();
         for (participant, info) in connections.iter() {
             match self.fetch_participant_state(info).await {
-                Ok(state) => match self.test_empty_msg(participant, info).await {
+                Ok(state) => match self.send_empty_msg(participant, info).await {
                     Ok(()) => {
                         status.insert(*participant, state);
                         participants.insert(participant, info.clone());
@@ -106,7 +106,7 @@ impl Pool {
         let mut participants = Participants::default();
         for (participant, info) in connections.iter() {
             match self.fetch_participant_state(info).await {
-                Ok(state) => match self.test_empty_msg(participant, info).await {
+                Ok(state) => match self.send_empty_msg(participant, info).await {
                     Ok(()) => {
                         status.insert(*participant, state);
                         participants.insert(participant, info.clone());
@@ -198,7 +198,7 @@ impl Pool {
         }
     }
 
-    async fn test_empty_msg(
+    async fn send_empty_msg(
         &self,
         participant: &Participant,
         participant_info: &ParticipantInfo,

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -70,6 +70,7 @@ impl Pool {
         let mut status = self.status.write().await;
         let mut participants = Participants::default();
         for (participant, info) in connections.iter() {
+<<<<<<< HEAD
             match self.fetch_participant_state(info).await {
                 Ok(state) => {
                     status.insert(*participant, state);
@@ -79,6 +80,43 @@ impl Pool {
                     tracing::warn!("Fetch state for participant {participant:?} with url {} has failed with error {e}.", info.url);
                 }
             }
+=======
+            let Ok(Ok(url)) = Url::parse(&info.url).map(|url| url.join("/state")) else {
+                tracing::error!(
+                    "Pool.ping url is invalid participant {:?} url {} /state",
+                    participant,
+                    info.url
+                );
+                continue;
+            };
+
+            let Ok(resp) = self
+                .http
+                .get(url.clone())
+                .timeout(Duration::from_millis(400))
+                .send()
+                .await
+            else {
+                tracing::warn!(
+                    "Pool.ping resp err participant {:?} url {}",
+                    participant,
+                    url
+                );
+                continue;
+            };
+
+            let Ok(state): Result<StateView, _> = resp.json().await else {
+                tracing::warn!(
+                    "Pool.ping state view err participant {:?} url {}",
+                    participant,
+                    url
+                );
+                continue;
+            };
+
+            status.insert(*participant, state);
+            participants.insert(participant, info.clone());
+>>>>>>> b340f1a0 (increase timeout)
         }
         drop(status);
 


### PR DESCRIPTION
added `test_empty_msg()` in the logic of establishing active participants.
Now to qualify as an active participant:
1) /state returns response fine;
2) sending empty message thru send_encrypted() returns Ok(());
