### PR TITLE
fix: prevent messages from taking too long to be sent

### DIFF
--- a/chain-signatures/node/src/http_client.rs
+++ b/chain-signatures/node/src/http_client.rs
@@ -206,12 +206,11 @@ impl MessageQueue {
         }
 
         let elapsed = outer.elapsed();
-        if elapsed > Duration::from_millis(100) && uncompacted > 0 {
+        if uncompacted > 0 {
             tracing::info!(
                 uncompacted,
                 compacted,
-                "{from:?} sent messages in {:?}",
-                elapsed,
+                "{from:?} sent messages in {elapsed:?}",
             );
         }
         crate::metrics::SEND_ENCRYPTED_LATENCY

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -206,7 +206,7 @@ impl Pool {
         let empty_msg: Vec<Ciphered> = Vec::new();
         crate::http_client::send_encrypted(
             *participant,
-            &self.http,
+            self.http.clone(),
             participant_info.url.clone(),
             empty_msg,
             self.fetch_participant_timeout,

--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -307,30 +307,11 @@ pub(crate) static PROTOCOL_LATENCY_ITER_MESSAGE: Lazy<HistogramVec> = Lazy::new(
     .unwrap()
 });
 
-pub(crate) static NUM_SEND_ENCRYPTED_FAILURE: Lazy<CounterVec> = Lazy::new(|| {
-    try_create_counter_vec(
-        "multichain_send_encrypted_failure",
-        "number of successful send encrypted",
-        &["node_account_id"],
-    )
-    .unwrap()
-});
-
 pub(crate) static NUM_SEND_ENCRYPTED_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
     try_create_counter_vec(
         "multichain_send_encrypted_total",
         "number total send encrypted",
         &["node_account_id"],
-    )
-    .unwrap()
-});
-
-pub(crate) static FAILED_SEND_ENCRYPTED_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
-    try_create_histogram_vec(
-        "multichain_failed_send_encrypted_ms",
-        "Latency of failed send encrypted.",
-        &["node_account_id"],
-        Some(exponential_buckets(0.5, 1.5, 20).unwrap()),
     )
     .unwrap()
 });

--- a/chain-signatures/node/src/protocol/consensus.rs
+++ b/chain-signatures/node/src/protocol/consensus.rs
@@ -6,6 +6,7 @@ use super::state::{
 use super::{Config, SignQueue};
 use crate::gcp::error::DatastoreStorageError;
 use crate::gcp::error::SecretStorageError;
+use crate::http_client::MessageQueue;
 use crate::protocol::contract::primitives::Participants;
 use crate::protocol::monitor::StuckMonitor;
 use crate::protocol::presignature::PresignatureManager;
@@ -170,7 +171,9 @@ impl ConsensusProtocol for StartedState {
                                                 ctx.my_account_id(),
                                             ),
                                         )),
-                                        messages: Default::default(),
+                                        messages: Arc::new(RwLock::new(MessageQueue::new(
+                                            ctx.my_account_id(),
+                                        ))),
                                     }))
                                 }
                                 None => Ok(NodeState::Joining(JoiningState {
@@ -224,7 +227,9 @@ impl ConsensusProtocol for StartedState {
                                 participants,
                                 threshold: contract_state.threshold,
                                 protocol,
-                                messages: Default::default(),
+                                messages: Arc::new(RwLock::new(MessageQueue::new(
+                                    ctx.my_account_id(),
+                                ))),
                             }))
                         }
                         None => {
@@ -760,6 +765,6 @@ async fn start_resharing<C: ConsensusCtx>(
         threshold: contract_state.threshold,
         public_key: contract_state.public_key,
         protocol,
-        messages: Default::default(),
+        messages: Arc::new(RwLock::new(MessageQueue::new(ctx.my_account_id()))),
     }))
 }

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -239,15 +239,17 @@ impl MpcSignProtocol {
             crate::metrics::PROTOCOL_ITER_CNT
                 .with_label_values(&[my_account_id.as_str()])
                 .inc();
+
+            let msg_time = Instant::now();
+            let mut msg_count = 0;
             loop {
                 let msg_result = self.receiver.try_recv();
                 match msg_result {
                     Ok(msg) => {
-                        tracing::debug!("received a new message");
+                        msg_count += 1;
                         queue.push(msg);
                     }
                     Err(TryRecvError::Empty) => {
-                        tracing::debug!("no new messages received");
                         break;
                     }
                     Err(TryRecvError::Disconnected) => {
@@ -256,6 +258,7 @@ impl MpcSignProtocol {
                     }
                 }
             }
+            tracing::debug!("received {msg_count} messages in {:?}", msg_time.elapsed());
 
             let contract_state = if last_state_update.elapsed() > Duration::from_secs(1) {
                 let contract_state = match rpc_client::fetch_mpc_contract_state(

--- a/integration-tests/chain-signatures/tests/actions/wait_for.rs
+++ b/integration-tests/chain-signatures/tests/actions/wait_for.rs
@@ -51,7 +51,7 @@ pub async fn running_mpc<'a>(
         }
     );
     is_running
-        .retry(&ExponentialBuilder::default().with_max_times(6))
+        .retry(&ExponentialBuilder::default().with_max_times(7))
         .await
         .with_context(|| err_msg)
 }

--- a/integration-tests/chain-signatures/tests/cases/mod.rs
+++ b/integration-tests/chain-signatures/tests/cases/mod.rs
@@ -28,7 +28,7 @@ async fn test_multichain_reshare() -> anyhow::Result<()> {
             actions::single_signature_production(&ctx, &state).await?;
 
             tracing::info!("!!! Add participant 3");
-            assert!(ctx.add_participant(None).await.is_ok());
+            ctx.add_participant(None).await.unwrap();
             let state = wait_for::running_mpc(&ctx, None).await?;
             wait_for::has_at_least_triples(&ctx, 2).await?;
             wait_for::has_at_least_presignatures(&ctx, 2).await?;
@@ -39,14 +39,12 @@ async fn test_multichain_reshare() -> anyhow::Result<()> {
                 state.participants.keys().nth(2).unwrap().clone().as_ref(),
             )
             .unwrap();
-            assert!(ctx.remove_participant(Some(&account_2)).await.is_ok());
+            ctx.remove_participant(Some(&account_2)).await.unwrap();
             let account_0 = near_workspaces::types::AccountId::from_str(
                 state.participants.keys().next().unwrap().clone().as_ref(),
             )
             .unwrap();
-            let node_cfg_0 = ctx.remove_participant(Some(&account_0)).await;
-            assert!(node_cfg_0.is_ok());
-            let node_cfg_0 = node_cfg_0.unwrap();
+            let node_cfg_0 = ctx.remove_participant(Some(&account_0)).await.unwrap();
             let state = wait_for::running_mpc(&ctx, None).await?;
             wait_for::has_at_least_triples(&ctx, 2).await?;
             wait_for::has_at_least_presignatures(&ctx, 2).await?;
@@ -56,14 +54,14 @@ async fn test_multichain_reshare() -> anyhow::Result<()> {
             assert!(ctx.remove_participant(None).await.is_err());
 
             tracing::info!("!!! Add participant 5");
-            assert!(ctx.add_participant(None).await.is_ok());
+            ctx.add_participant(None).await.unwrap();
             let state = wait_for::running_mpc(&ctx, None).await?;
             wait_for::has_at_least_triples(&ctx, 2).await?;
             wait_for::has_at_least_presignatures(&ctx, 2).await?;
             actions::single_signature_production(&ctx, &state).await?;
 
             tracing::info!("!!! Add back participant 0");
-            assert!(ctx.add_participant(Some(node_cfg_0)).await.is_ok());
+            ctx.add_participant(Some(node_cfg_0)).await.unwrap();
             let state = wait_for::running_mpc(&ctx, None).await?;
             wait_for::has_at_least_triples(&ctx, 2).await?;
             wait_for::has_at_least_presignatures(&ctx, 2).await?;
@@ -331,19 +329,19 @@ async fn test_multichain_reshare_with_lake_congestion() -> anyhow::Result<()> {
             add_latency(&ctx.nodes.proxy_name_for_node(1), true, 1.0, 1_000, 100).await?;
             // remove node2, node0 and node1 should still reach concensus
             // this fails if the latency above is too long (10s)
-            assert!(ctx.remove_participant(None).await.is_ok());
+            ctx.remove_participant(None).await.unwrap();
             let state = wait_for::running_mpc(&ctx, Some(0)).await?;
             assert!(state.participants.len() == 2);
             // Going below T should error out
             assert!(ctx.remove_participant(None).await.is_err());
             let state = wait_for::running_mpc(&ctx, Some(0)).await?;
             assert!(state.participants.len() == 2);
-            assert!(ctx.add_participant(None).await.is_ok());
+            ctx.add_participant(None).await.unwrap();
             // add latency to node2->rpc
             add_latency(&ctx.nodes.proxy_name_for_node(2), true, 1.0, 1_000, 100).await?;
             let state = wait_for::running_mpc(&ctx, Some(0)).await?;
             assert!(state.participants.len() == 3);
-            assert!(ctx.remove_participant(None).await.is_ok());
+            ctx.remove_participant(None).await.unwrap();
             let state = wait_for::running_mpc(&ctx, Some(0)).await?;
             assert!(state.participants.len() == 2);
             // make sure signing works after reshare

--- a/integration-tests/chain-signatures/tests/lib.rs
+++ b/integration-tests/chain-signatures/tests/lib.rs
@@ -61,7 +61,7 @@ impl MultichainTestContext<'_> {
 
         self.nodes.start_node(&self.cfg, &node_account).await?;
         // Wait for new node to add itself as a candidate
-        tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(20)).await;
 
         // T number of participants should vote
         let participants = self.participant_accounts().await?;


### PR DESCRIPTION
messages will occasionally take over 1s to send, which can stall the node from doing work. This PR makes all the `send_encrypted` be ran concurrently such that the node don't wait until the previous `send_encrypted` gets completed. I've seen the message sending portion go from 1-2s max to 300ms max so this should be a good improvement with no breaking changes