### PR TITLE
fix: Smart contract panicked: Callback computation 0 was not successful

### DIFF
--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -41,10 +41,10 @@ const GAS_FOR_SIGN_CALL: Gas = Gas::from_tgas(50);
 const DATA_ID_REGISTER: u64 = 0;
 
 // Prepaid gas for a `clear_state_on_finish` call
-const CLEAR_STATE_ON_FINISH_CALL_GAS: Gas = Gas::from_tgas(10);
+const CLEAR_STATE_ON_FINISH_CALL_GAS: Gas = Gas::from_tgas(20);
 
 // Prepaid gas for a `return_signature_on_finish` call
-const RETURN_SIGNATURE_ON_FINISH_CALL_GAS: Gas = Gas::from_tgas(5);
+const RETURN_SIGNATURE_ON_FINISH_CALL_GAS: Gas = Gas::from_tgas(10);
 
 // Prepaid gas for a `update_config` call
 const UPDATE_CONFIG_GAS: Gas = Gas::from_tgas(5);


### PR DESCRIPTION
problem was prepaid gas for clear_state_on_finish was too low. 
I doubled prepaid gas for both clear_state_on_finish and return_signature_on_finish