### PR TITLE
fix: presignature storage locks

### DIFF
--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -218,7 +218,7 @@ impl PresignatureManager {
     /// Returns true if the presignature with the given id is already generated
     pub async fn contains(&self, id: &PresignatureId) -> bool {
         self.presignature_storage
-            .write()
+            .read()
             .await
             .contains(id)
             .await
@@ -231,7 +231,7 @@ impl PresignatureManager {
     /// Returns true if the mine presignature with the given id is already generated
     pub async fn contains_mine(&self, id: &PresignatureId) -> bool {
         self.presignature_storage
-            .write()
+            .read()
             .await
             .contains_mine(id)
             .await
@@ -291,7 +291,7 @@ impl PresignatureManager {
     /// Returns the number of unspent presignatures available in the manager.
     pub async fn len_generated(&self) -> usize {
         self.presignature_storage
-            .write()
+            .read()
             .await
             .len_generated()
             .await
@@ -304,7 +304,7 @@ impl PresignatureManager {
     /// Returns the number of unspent presignatures assigned to this node.
     pub async fn len_mine(&self) -> usize {
         self.presignature_storage
-            .write()
+            .read()
             .await
             .len_mine()
             .await

--- a/chain-signatures/node/src/storage/presignature_storage.rs
+++ b/chain-signatures/node/src/storage/presignature_storage.rs
@@ -48,13 +48,13 @@ impl PresignatureRedisStorage {
         Ok(())
     }
 
-    pub async fn contains(&mut self, id: &PresignatureId) -> PresigResult<bool> {
+    pub async fn contains(&self, id: &PresignatureId) -> PresigResult<bool> {
         let mut connection = self.redis_pool.get().await?;
         let result: bool = connection.hexists(self.presig_key(), id).await?;
         Ok(result)
     }
 
-    pub async fn contains_mine(&mut self, id: &PresignatureId) -> PresigResult<bool> {
+    pub async fn contains_mine(&self, id: &PresignatureId) -> PresigResult<bool> {
         let mut connection = self.redis_pool.get().await?;
         let result: bool = connection.sismember(self.mine_key(), id).await?;
         Ok(result)
@@ -87,13 +87,13 @@ impl PresignatureRedisStorage {
         }
     }
 
-    pub async fn len_generated(&mut self) -> PresigResult<usize> {
+    pub async fn len_generated(&self) -> PresigResult<usize> {
         let mut connection = self.redis_pool.get().await?;
         let result: usize = connection.hlen(self.presig_key()).await?;
         Ok(result)
     }
 
-    pub async fn len_mine(&mut self) -> PresigResult<usize> {
+    pub async fn len_mine(&self) -> PresigResult<usize> {
         let mut connection = self.redis_pool.get().await?;
         let result: usize = connection.scard(self.mine_key()).await?;
         Ok(result)

--- a/chain-signatures/node/src/storage/triple_storage.rs
+++ b/chain-signatures/node/src/storage/triple_storage.rs
@@ -41,13 +41,13 @@ impl TripleRedisStorage {
         Ok(())
     }
 
-    pub async fn contains(&mut self, id: &TripleId) -> TripleResult<bool> {
+    pub async fn contains(&self, id: &TripleId) -> TripleResult<bool> {
         let mut conn = self.redis_pool.get().await?;
         let result: bool = conn.hexists(self.triple_key(), id).await?;
         Ok(result)
     }
 
-    pub async fn contains_mine(&mut self, id: &TripleId) -> TripleResult<bool> {
+    pub async fn contains_mine(&self, id: &TripleId) -> TripleResult<bool> {
         let mut conn = self.redis_pool.get().await?;
         let result: bool = conn.sismember(self.mine_key(), id).await?;
         Ok(result)
@@ -79,13 +79,13 @@ impl TripleRedisStorage {
         }
     }
 
-    pub async fn len_generated(&mut self) -> TripleResult<usize> {
+    pub async fn len_generated(&self) -> TripleResult<usize> {
         let mut conn = self.redis_pool.get().await?;
         let result: usize = conn.hlen(self.triple_key()).await?;
         Ok(result)
     }
 
-    pub async fn len_mine(&mut self) -> TripleResult<usize> {
+    pub async fn len_mine(&self) -> TripleResult<usize> {
         let mut conn = self.redis_pool.get().await?;
         let result: usize = conn.scard(self.mine_key()).await?;
         Ok(result)


### PR DESCRIPTION
The mutability and lock acquisition was being done incorrectly, where multiple write locks were trying to be acquired