### PR TITLE
FIX: allowed boot disk to be reused when VM is rebuilt

### DIFF
--- a/infra/modules/mig_template/main.tf
+++ b/infra/modules/mig_template/main.tf
@@ -3,17 +3,17 @@
 #########
 
 locals {
-  source_image         = var.source_image != "" ? var.source_image : "centos-7-v20201112"
-  source_image_family  = var.source_image_family != "" ? var.source_image_family : "centos-7"
-  source_image_project = var.source_image_project != "" ? var.source_image_project : "centos-cloud"
 
   boot_disk = [
     {
-      source_image = var.source_image != "" ? format("${local.source_image_project}/${local.source_image}") : format("${local.source_image_project}/${local.source_image_family}")
+      source_image = var.source_image
       disk_size_gb = var.disk_size_gb
       disk_type    = var.disk_type
       disk_labels  = var.disk_labels
       auto_delete  = var.auto_delete
+      device_name  = var.device_name
+      interface    = var.interface
+      mode         = var.mode
       boot         = "true"
     },
   ]
@@ -156,7 +156,7 @@ resource "google_compute_instance_template" "tpl" {
 
   lifecycle {
     create_before_destroy = "true"
-    ignore_changes = [ disk[0].source_image, labels ]
+    ignore_changes        = [disk[0].source_image, labels]
   }
 
   scheduling {

--- a/infra/modules/mig_template/variables.tf
+++ b/infra/modules/mig_template/variables.tf
@@ -104,19 +104,21 @@ variable "resource_policies" {
 variable "source_image" {
   description = "Source disk image. If neither source_image nor source_image_family is specified, defaults to the latest public CentOS image."
   type        = string
-  default     = ""
 }
 
-variable "source_image_family" {
-  description = "Source image family. If neither source_image nor source_image_family is specified, defaults to the latest public CentOS image."
-  type        = string
-  default     = "centos-7"
+variable "device_name" {
+  description = "Disk device name"
+  default     = "persistent-disk-0"
 }
 
-variable "source_image_project" {
-  description = "Project where the source image comes from. The default project contains CentOS images."
-  type        = string
-  default     = "centos-cloud"
+variable "interface" {
+  default     = "SCSI"
+  description = "Interface type of the boot disk"
+}
+
+variable "mode" {
+  default     = "READ_WRITE"
+  description = "Boot disk mode"
 }
 
 variable "disk_size_gb" {
@@ -146,7 +148,7 @@ variable "disk_encryption_key" {
 variable "auto_delete" {
   description = "Whether or not the boot disk should be auto-deleted"
   type        = string
-  default     = "true"
+  default     = "false"
 }
 
 variable "additional_disks" {

--- a/infra/multichain-dev/main.tf
+++ b/infra/multichain-dev/main.tf
@@ -19,13 +19,13 @@ module "gce-container" {
   container = {
     image = "europe-west1-docker.pkg.dev/near-cs-dev/multichain-public/multichain-dev:latest"
 
-    port  = "3000"
+    port = "3000"
 
     volumeMounts = [
       {
         mountPath = "/data"
-        name = "host-path"
-        readOnly = false
+        name      = "host-path"
+        readOnly  = false
       }
     ]
 
@@ -75,20 +75,20 @@ module "gce-container" {
         value = var.env
       },
       {
-        name = "MPC_REDIS_URL",
+        name  = "MPC_REDIS_URL",
         value = var.redis_url
       }
     ])
   }
 
   volumes = [
-      {
-        name = "host-path"
-        hostPath = {
-          path = "/var/redis"
-        }
+    {
+      name = "host-path"
+      hostPath = {
+        path = "/var/redis"
       }
-    ]
+    }
+  ]
 }
 
 resource "google_service_account" "service_account" {
@@ -131,14 +131,12 @@ module "mig_template" {
     email  = google_service_account.service_account.email,
     scopes = ["cloud-platform"]
   }
-  name_prefix          = "multichain-${count.index}"
-  source_image_family  = "cos-113-lts"
-  source_image_project = "cos-cloud"
-  machine_type         = "e2-medium"
+  name_prefix  = "multichain-${count.index}"
+  machine_type = "e2-medium"
 
   startup_script = "docker rm watchtower ; docker run -d --name watchtower -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --debug --interval 30"
 
-  source_image = reverse(split("/", module.gce-container[count.index].source_image))[0]
+  source_image = var.source_image
   metadata     = merge(var.additional_metadata, { "gce-container-declaration" = module.gce-container["${count.index}"].metadata_value })
   tags = [
     "multichain"

--- a/infra/multichain-dev/variables.tf
+++ b/infra/multichain-dev/variables.tf
@@ -16,6 +16,11 @@ variable "mig_name" {
   default     = "mpc-mig"
 }
 
+variable "source_image" {
+  type    = string
+  default = "projects/cos-cloud/global/images/cos-stable-117-18613-75-37"
+}
+
 variable "image" {
   description = "The Docker image to deploy to GCE instances"
   type        = string
@@ -79,10 +84,6 @@ variable "env" {
   default = "dev"
 }
 
-variable "redis_url" {
-  type = string
-  default = "redis://127.0.0.1:6379"
-}
 
 variable "static_env" {
   type = list(object({
@@ -92,7 +93,7 @@ variable "static_env" {
   default = [
     {
       name  = "MPC_NEAR_RPC"
-      value = "https://rpc.testnet.near.org"
+      value = "https://rpc.testnet.fastnear.com"
     },
     {
       name  = "MPC_CONTRACT_ID"
@@ -104,7 +105,7 @@ variable "static_env" {
     },
     {
       name  = "MPC_INDEXER_START_BLOCK_HEIGHT"
-      value = 178736306
+      value = 180133172
     },
     {
       name  = "AWS_DEFAULT_REGION"
@@ -130,6 +131,6 @@ variable "static_env" {
 }
 
 variable "redis_url" {
-  type = string
+  type    = string
   default = "redis://127.0.0.1:6379"
 }

--- a/infra/multichain-mainnet/main.tf
+++ b/infra/multichain-mainnet/main.tf
@@ -15,8 +15,16 @@ module "gce-container" {
 
   container = {
     image = var.image
-    args  = ["start"]
-    port  = "3000"
+
+    port = "3000"
+
+    volumeMounts = [
+      {
+        mountPath = "/data"
+        name      = "host-path"
+        readOnly  = false
+      }
+    ]
 
     env = concat(var.static_env, [
       {
@@ -62,9 +70,22 @@ module "gce-container" {
       {
         name  = "MPC_ENV",
         value = var.env
+      },
+      {
+        name  = "MPC_REDIS_URL",
+        value = var.redis_url
       }
     ])
   }
+
+  volumes = [
+    {
+      name = "host-path"
+      hostPath = {
+        path = "/var/redis"
+      }
+    }
+  ]
 }
 
 resource "google_service_account" "service_account" {

--- a/infra/multichain-mainnet/variables.tf
+++ b/infra/multichain-mainnet/variables.tf
@@ -20,6 +20,11 @@ variable "image" {
   default     = "us-east1-docker.pkg.dev/near-cs-mainnet/multichain-public/multichain-mainnet:latest"
 }
 
+variable "source_image" {
+  type    = string
+  default = "projects/cos-cloud/global/images/cos-stable-117-18613-75-37"
+}
+
 variable "image_port" {
   description = "The port the image exposes for HTTP requests"
   type        = number
@@ -43,8 +48,8 @@ variable "network" {
 variable "additional_metadata" {
   type        = map(any)
   description = "Additional metadata to attach to the instance"
-  default     = {
-    cos-update-strategy:	"update_enabled"
+  default = {
+    cos-update-strategy : "update_enabled"
   }
 }
 
@@ -77,7 +82,7 @@ variable "node_configs" {
 }
 
 variable "env" {
-  type = string
+  type    = string
   default = "mainnet"
 }
 
@@ -132,5 +137,5 @@ variable "static_env" {
 
 variable "domain" {
   description = "DNS name for your node"
-  default = null
+  default     = null
 }

--- a/infra/multichain-mainnet/variables.tf
+++ b/infra/multichain-mainnet/variables.tf
@@ -94,7 +94,7 @@ variable "static_env" {
   default = [
     {
       name  = "MPC_NEAR_RPC"
-      value = "https://rpc.mainnet.near.org"
+      value = "https://rpc.mainnet.fastnear.com"
     },
     {
       name  = "MPC_CONTRACT_ID"
@@ -138,4 +138,9 @@ variable "static_env" {
 variable "domain" {
   description = "DNS name for your node"
   default     = null
+}
+
+variable "redis_url" {
+  type    = string
+  default = "redis://127.0.0.1:6379"
 }

--- a/infra/multichain-testnet/main.tf
+++ b/infra/multichain-testnet/main.tf
@@ -78,11 +78,11 @@ resource "google_service_account" "service_account" {
 
 resource "google_project_iam_member" "sa-roles" {
   for_each = toset([
-      "roles/datastore.user",
-      "roles/secretmanager.admin",
-      "roles/storage.objectAdmin",
-      "roles/iam.serviceAccountAdmin",
-      "roles/logging.logWriter"
+    "roles/datastore.user",
+    "roles/secretmanager.admin",
+    "roles/storage.objectAdmin",
+    "roles/iam.serviceAccountAdmin",
+    "roles/logging.logWriter"
   ])
 
   role    = each.key
@@ -106,14 +106,12 @@ module "ig_template" {
     email  = google_service_account.service_account.email,
     scopes = ["cloud-platform"]
   }
-  name_prefix          = "multichain-testnet-${count.index}"
-  source_image_family  = "cos-113-lts"
-  source_image_project = "cos-cloud"
-  machine_type         = "n2d-standard-2"
+  name_prefix  = "multichain-testnet-${count.index}"
+  machine_type = "n2d-standard-2"
 
   startup_script = "docker rm watchtower ; docker run -d --name watchtower -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --debug --interval 30"
 
-  source_image = reverse(split("/", module.gce-container[count.index].source_image))[0]
+  source_image = var.source_image
   metadata     = merge(var.additional_metadata, { "gce-container-declaration" = module.gce-container["${count.index}"].metadata_value })
   tags = [
     "multichain"

--- a/infra/multichain-testnet/main.tf
+++ b/infra/multichain-testnet/main.tf
@@ -15,8 +15,15 @@ module "gce-container" {
 
   container = {
     image = var.image
-    args  = ["start"]
-    port  = "3000"
+
+    port = "3000"
+    volumeMounts = [
+      {
+        mountPath = "/data"
+        name      = "host-path"
+        readOnly  = false
+      }
+    ]
 
     env = concat(var.static_env, [
       {
@@ -67,8 +74,20 @@ module "gce-container" {
         name  = "MPC_GCP_PROJECT_ID"
         value = var.project_id
       },
+      {
+        name  = "MPC_REDIS_URL",
+        value = var.redis_url
+      }
     ])
   }
+  volumes = [
+    {
+      name = "host-path"
+      hostPath = {
+        path = "/var/redis"
+      }
+    }
+  ]
 }
 
 resource "google_service_account" "service_account" {

--- a/infra/multichain-testnet/variables.tf
+++ b/infra/multichain-testnet/variables.tf
@@ -20,6 +20,11 @@ variable "image" {
   default     = "europe-west1-docker.pkg.dev/near-cs-testnet/multichain-public/multichain-testnet:latest"
 }
 
+variable "source_image" {
+  type    = string
+  default = "projects/cos-cloud/global/images/cos-stable-117-18613-75-37"
+}
+
 variable "image_port" {
   description = "The port the image exposes for HTTP requests"
   type        = number
@@ -43,8 +48,8 @@ variable "network" {
 variable "additional_metadata" {
   type        = map(any)
   description = "Additional metadata to attach to the instance"
-  default     = {
-    cos-update-strategy:	"update_enabled"
+  default = {
+    cos-update-strategy : "update_enabled"
   }
 }
 

--- a/infra/multichain-testnet/variables.tf
+++ b/infra/multichain-testnet/variables.tf
@@ -93,7 +93,7 @@ variable "static_env" {
   default = [
     {
       name  = "MPC_NEAR_RPC"
-      value = "https://rpc.testnet.near.org"
+      value = "https://rpc.testnet.fastnear.com"
     },
     {
       name  = "MPC_CONTRACT_ID"
@@ -129,4 +129,9 @@ variable "static_env" {
 variable "create_network" {
   default     = false
   description = "Do you want to create a new VPC network (true) or use default GCP network (false)?"
+}
+
+variable "redis_url" {
+  type    = string
+  default = "redis://127.0.0.1:6379"
 }

--- a/infra/partner-mainnet/main.tf
+++ b/infra/partner-mainnet/main.tf
@@ -6,7 +6,7 @@ provider "google-beta" {
 }
 
 resource "google_compute_project_metadata_item" "project_logging" {
-  key = "google-logging-enabled"
+  key   = "google-logging-enabled"
   value = "true"
 }
 module "gce-container" {
@@ -82,9 +82,9 @@ resource "google_project_iam_member" "sa-roles" {
     "roles/logging.logWriter",
   ])
 
-  role     = each.key
-  member   = "serviceAccount:${google_service_account.service_account.email}"
-   project = var.project_id
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.service_account.email}"
+  project = var.project_id
 }
 
 resource "google_compute_global_address" "external_ips" {
@@ -116,14 +116,12 @@ module "ig_template" {
     email  = google_service_account.service_account.email,
     scopes = ["cloud-platform"]
   }
-  name_prefix          = "multichain-partner-mainnet-${count.index}"
-  source_image_family  = "cos-113-lts"
-  source_image_project = "cos-cloud"
-  machine_type         = "n2d-standard-2"
+  name_prefix  = "multichain-partner-mainnet-${count.index}"
+  machine_type = "n2d-standard-2"
 
   startup_script = "docker rm watchtower ; docker run -d --name watchtower -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --debug --interval 30"
 
-  source_image = reverse(split("/", module.gce-container[count.index].source_image))[0]
+  source_image = var.source_image
   metadata     = merge(var.additional_metadata, { "gce-container-declaration" = module.gce-container["${count.index}"].metadata_value })
   tags = [
     "multichain",
@@ -214,10 +212,10 @@ resource "google_compute_backend_service" "multichain_backend" {
   count                 = length(var.node_configs)
   name                  = "multichain-partner-mainnet-backend-service-${count.index}"
   load_balancing_scheme = "EXTERNAL"
-  
+
 
   log_config {
-    enable = true
+    enable      = true
     sample_rate = 0.5
   }
   backend {

--- a/infra/partner-mainnet/main.tf
+++ b/infra/partner-mainnet/main.tf
@@ -16,8 +16,15 @@ module "gce-container" {
 
   container = {
     image = var.image
-    args  = ["start"]
-    port  = "3000"
+
+    port = "3000"
+    volumeMounts = [
+      {
+        mountPath = "/data"
+        name      = "host-path"
+        readOnly  = false
+      }
+    ]
 
     env = concat(var.static_env, [
       {
@@ -63,9 +70,21 @@ module "gce-container" {
       {
         name  = "MPC_ENV",
         value = var.env
+      },
+      {
+        name  = "MPC_REDIS_URL",
+        value = var.redis_url
       }
     ])
   }
+  volumes = [
+    {
+      name = "host-path"
+      hostPath = {
+        path = "/var/redis"
+      }
+    }
+  ]
 }
 
 resource "google_service_account" "service_account" {

--- a/infra/partner-mainnet/network.tf
+++ b/infra/partner-mainnet/network.tf
@@ -1,44 +1,44 @@
 module "vpc" {
-    count = var.create_network ? 1 : 0
-    source  = "terraform-google-modules/network/google"
-    version = "~> 9.0"
+  count   = var.create_network ? 1 : 0
+  source  = "terraform-google-modules/network/google"
+  version = "~> 9.0"
 
-    project_id   = var.project_id
-    network_name = var.network
-    routing_mode = "GLOBAL"
+  project_id   = var.project_id
+  network_name = var.network
+  routing_mode = "GLOBAL"
 
-    subnets = [
+  subnets = [
+    {
+      subnet_name   = var.subnetwork
+      subnet_ip     = "10.10.10.0/24"
+      subnet_region = var.region
+    }
+  ]
+
+  routes = [
+    {
+      name              = "egress-internet"
+      description       = "route through IGW to access internet"
+      destination_range = "0.0.0.0/0"
+      tags              = "egress-inet"
+      next_hop_internet = "true"
+    }
+  ]
+
+  ingress_rules = [
+    {
+      name          = "allow-iap-ssh"
+      description   = "this rule allows you to connect to your VM via SSH without port 22 being public"
+      source_ranges = ["35.235.240.0/20"]
+      target_tags   = ["allow-ssh"]
+      allow = [
         {
-            subnet_name           = var.subnetwork
-            subnet_ip             = "10.10.10.0/24"
-            subnet_region         = var.region
+          protocol = "tcp",
+          ports    = ["22"]
         }
-    ]
-
-    routes = [
-        {
-            name                   = "egress-internet"
-            description            = "route through IGW to access internet"
-            destination_range      = "0.0.0.0/0"
-            tags                   = "egress-inet"
-            next_hop_internet      = "true"
-        }
-    ]
-
-    ingress_rules = [ 
-      {
-        name = "allow-iap-ssh"
-        description = "this rule allows you to connect to your VM via SSH without port 22 being public"
-        source_ranges = [ "35.235.240.0/20" ]
-        target_tags = [ "allow-ssh" ]
-        allow = [ 
-            {
-            protocol = "tcp",
-            ports = ["22"]
-          } 
-        ]
-      },
-     ]
+      ]
+    },
+  ]
 }
 
 resource "google_compute_router" "router" {
@@ -50,10 +50,10 @@ resource "google_compute_router" "router" {
 }
 
 resource "google_compute_router_nat" "nat" {
-  count                             = var.create_network ? 1 : 0
-  name                              = "nat"
-  router                            = google_compute_router.router[count.index].name
-  region                            = var.region
+  count                              = var.create_network ? 1 : 0
+  name                               = "nat"
+  router                             = google_compute_router.router[count.index].name
+  region                             = var.region
   nat_ip_allocate_option             = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 }

--- a/infra/partner-mainnet/terraform-mainnet-example.tfvars
+++ b/infra/partner-mainnet/terraform-mainnet-example.tfvars
@@ -1,16 +1,16 @@
-env          = "mainnet"
-project_id   = "<your-project-id>"
-network      = "default"
-subnetwork   = "default"
-image        = "us-east1-docker.pkg.dev/pagoda-discovery-platform-prod/multichain-public/multichain-mainnet:latest"
-region       = "europe-west1"
-zone         = "europe-west1-b"
+env        = "mainnet"
+project_id = "<your-project-id>"
+network    = "default"
+subnetwork = "default"
+image      = "us-east1-docker.pkg.dev/pagoda-discovery-platform-prod/multichain-public/multichain-mainnet:latest"
+region     = "europe-west1"
+zone       = "europe-west1-b"
 # These will be specific to your node
 node_configs = [
   {
     # Each node has a unique account ID
-    account              = "{your_near_account_id}"
-    cipher_pk            = "<your_cipher_pk>"
+    account   = "{your_near_account_id}"
+    cipher_pk = "<your_cipher_pk>"
     # These 3 values below should match your secret names in google secrets manager
     account_sk_secret_id = "multichain-account-sk-mainnet-0"
     cipher_sk_secret_id  = "multichain-cipher-sk-mainnet-0"

--- a/infra/partner-mainnet/variables.tf
+++ b/infra/partner-mainnet/variables.tf
@@ -94,7 +94,7 @@ variable "static_env" {
   default = [
     {
       name  = "MPC_NEAR_RPC"
-      value = "https://rpc.mainnet.near.org"
+      value = "https://rpc.mainnet.fastnear.com"
     },
     {
       name  = "MPC_CONTRACT_ID"
@@ -143,4 +143,9 @@ variable "create_network" {
 variable "domain" {
   description = "DNS name for your node"
   default     = ""
+}
+
+variable "redis_url" {
+  type    = string
+  default = "redis://127.0.0.1:6379"
 }

--- a/infra/partner-mainnet/variables.tf
+++ b/infra/partner-mainnet/variables.tf
@@ -20,6 +20,11 @@ variable "image" {
   default     = "us-east1-docker.pkg.dev/pagoda-discovery-platform-prod/multichain-public/multichain-mainnet:latest"
 }
 
+variable "source_image" {
+  type    = string
+  default = "projects/cos-cloud/global/images/cos-stable-117-18613-75-37"
+}
+
 variable "image_port" {
   description = "The port the image exposes for HTTP requests"
   type        = number
@@ -137,5 +142,5 @@ variable "create_network" {
 
 variable "domain" {
   description = "DNS name for your node"
-  default = ""
+  default     = ""
 }

--- a/infra/partner-testnet/main.tf
+++ b/infra/partner-testnet/main.tf
@@ -6,7 +6,7 @@ provider "google-beta" {
 }
 
 resource "google_compute_project_metadata_item" "project_logging" {
-  key = "google-logging-enabled"
+  key   = "google-logging-enabled"
   value = "true"
 }
 module "gce-container" {
@@ -82,7 +82,7 @@ resource "google_project_iam_member" "sa-roles" {
     "roles/logging.logWriter",
   ])
 
-  role = each.key
+  role    = each.key
   member  = "serviceAccount:${google_service_account.service_account.email}"
   project = var.project_id
 }
@@ -103,14 +103,12 @@ module "ig_template" {
     email  = google_service_account.service_account.email,
     scopes = ["cloud-platform"]
   }
-  name_prefix          = "multichain-partner-${count.index}"
-  source_image_family  = "cos-stable"
-  source_image_project = "cos-cloud"
-  machine_type         = "n2d-standard-2"
+  name_prefix  = "multichain-partner-${count.index}"
+  machine_type = "n2d-standard-2"
 
   startup_script = "docker rm watchtower ; docker run -d --name watchtower -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --debug --interval 30"
 
-  source_image = reverse(split("/", module.gce-container[count.index].source_image))[0]
+  source_image = var.source_image
   metadata     = merge(var.additional_metadata, { "gce-container-declaration" = module.gce-container["${count.index}"].metadata_value })
   tags = [
     "multichain",

--- a/infra/partner-testnet/main.tf
+++ b/infra/partner-testnet/main.tf
@@ -16,8 +16,15 @@ module "gce-container" {
 
   container = {
     image = var.image
-    args  = ["start"]
-    port  = "3000"
+
+    port = "3000"
+    volumeMounts = [
+      {
+        mountPath = "/data"
+        name      = "host-path"
+        readOnly  = false
+      }
+    ]
 
     env = concat(var.static_env, [
       {
@@ -63,9 +70,21 @@ module "gce-container" {
       {
         name  = "MPC_ENV",
         value = var.env
+      },
+      {
+        name  = "MPC_REDIS_URL",
+        value = var.redis_url
       }
     ])
   }
+  volumes = [
+    {
+      name = "host-path"
+      hostPath = {
+        path = "/var/redis"
+      }
+    }
+  ]
 }
 
 resource "google_service_account" "service_account" {

--- a/infra/partner-testnet/network.tf
+++ b/infra/partner-testnet/network.tf
@@ -1,44 +1,44 @@
 module "vpc" {
-    count = var.create_network ? 1 : 0
-    source  = "terraform-google-modules/network/google"
-    version = "~> 9.0"
+  count   = var.create_network ? 1 : 0
+  source  = "terraform-google-modules/network/google"
+  version = "~> 9.0"
 
-    project_id   = var.project_id
-    network_name = var.network
-    routing_mode = "GLOBAL"
+  project_id   = var.project_id
+  network_name = var.network
+  routing_mode = "GLOBAL"
 
-    subnets = [
+  subnets = [
+    {
+      subnet_name   = var.subnetwork
+      subnet_ip     = "10.10.10.0/24"
+      subnet_region = var.region
+    }
+  ]
+
+  routes = [
+    {
+      name              = "egress-internet"
+      description       = "route through IGW to access internet"
+      destination_range = "0.0.0.0/0"
+      tags              = "egress-inet"
+      next_hop_internet = "true"
+    }
+  ]
+
+  ingress_rules = [
+    {
+      name          = "allow-iap-ssh"
+      description   = "this rule allows you to connect to your VM via SSH without port 22 being public"
+      source_ranges = ["35.235.240.0/20"]
+      target_tags   = ["allow-ssh"]
+      allow = [
         {
-            subnet_name           = var.subnetwork
-            subnet_ip             = "10.10.10.0/24"
-            subnet_region         = var.region
+          protocol = "tcp",
+          ports    = ["22"]
         }
-    ]
-
-    routes = [
-        {
-            name                   = "egress-internet"
-            description            = "route through IGW to access internet"
-            destination_range      = "0.0.0.0/0"
-            tags                   = "egress-inet"
-            next_hop_internet      = "true"
-        }
-    ]
-
-    ingress_rules = [ 
-      {
-        name = "allow-iap-ssh"
-        description = "this rule allows you to connect to your VM via SSH without port 22 being public"
-        source_ranges = [ "35.235.240.0/20" ]
-        target_tags = [ "allow-ssh" ]
-        allow = [ 
-            {
-            protocol = "tcp",
-            ports = ["22"]
-          } 
-        ]
-      },
-     ]
+      ]
+    },
+  ]
 }
 
 resource "google_compute_router" "router" {
@@ -49,9 +49,9 @@ resource "google_compute_router" "router" {
 }
 
 resource "google_compute_router_nat" "nat" {
-  name = "nat"
-  router = google_compute_router.router.name
-  region = var.region
-  nat_ip_allocate_option = "AUTO_ONLY"
+  name                               = "nat"
+  router                             = google_compute_router.router.name
+  region                             = var.region
+  nat_ip_allocate_option             = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 }

--- a/infra/partner-testnet/terraform-testnet-example.tfvars
+++ b/infra/partner-testnet/terraform-testnet-example.tfvars
@@ -1,16 +1,16 @@
-env          = "testnet"
-project_id   = "<your-project-id>"
-network      = "default"
-subnetwork   = "default"
-image        = "us-east1-docker.pkg.dev/pagoda-discovery-platform-prod/multichain-public/multichain-testnet:latest"
-region       = "europe-west1"
-zone         = "europe-west1-b"
+env        = "testnet"
+project_id = "<your-project-id>"
+network    = "default"
+subnetwork = "default"
+image      = "us-east1-docker.pkg.dev/pagoda-discovery-platform-prod/multichain-public/multichain-testnet:latest"
+region     = "europe-west1"
+zone       = "europe-west1-b"
 # These will be specific to your node
 node_configs = [
   {
     # Each node has a unique account ID
-    account              = "{your_near_account_id}"
-    cipher_pk            = "<your_cipher_pk>"
+    account   = "{your_near_account_id}"
+    cipher_pk = "<your_cipher_pk>"
     # These 3 values below should match your secret names in google secrets manager
     account_sk_secret_id = "multichain-account-sk-testnet-0"
     cipher_sk_secret_id  = "multichain-cipher-sk-testnet-0"

--- a/infra/partner-testnet/variables.tf
+++ b/infra/partner-testnet/variables.tf
@@ -91,7 +91,7 @@ variable "static_env" {
   default = [
     {
       name  = "MPC_NEAR_RPC"
-      value = "https://rpc.testnet.near.org"
+      value = "https://rpc.testnet.fastnear.com"
     },
     {
       name  = "MPC_CONTRACT_ID"
@@ -131,4 +131,9 @@ variable "static_env" {
 variable "create_network" {
   default     = false
   description = "Do you want to create a new VPC network (true) or use default GCP network (false)?"
+}
+
+variable "redis_url" {
+  type    = string
+  default = "redis://127.0.0.1:6379"
 }

--- a/infra/partner-testnet/variables.tf
+++ b/infra/partner-testnet/variables.tf
@@ -20,6 +20,11 @@ variable "image" {
   default     = "us-east1-docker.pkg.dev/pagoda-discovery-platform-prod/multichain-public/multichain-testnet:latest"
 }
 
+variable "source_image" {
+  type    = string
+  default = "projects/cos-cloud/global/images/cos-stable-117-18613-75-37"
+}
+
 variable "image_port" {
   description = "The port the image exposes for HTTP requests"
   type        = number


### PR DESCRIPTION
@volovyks and I discovered an issue when changing ENV vars and rebuilding the VM with Terraform, it also deleted and re-created the boot disk. These changes should do a few things:
1. Reuse the original boot disk so we can keep our triples and presignatures
2. Allow better versioning for source images
3. fix some formatting issues
4. Add TF for utilizing Redis instead of Datastore
5. Change RPC provider URLs